### PR TITLE
Feature/196 add htmlmarkdown page blocks to fabricator

### DIFF
--- a/app/Filament/Fabricator/PageBlocks/HTMLBlock.php
+++ b/app/Filament/Fabricator/PageBlocks/HTMLBlock.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Filament\Fabricator\PageBlocks;
+
+use Filament\Forms\Components\Builder\Block;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\Toggle;
+use Mews\Purifier\Facades\Purifier;
+use Z3d0X\FilamentFabricator\PageBlocks\PageBlock;
+
+class HTMLBlock extends PageBlock
+{
+    public static function getBlockSchema(): Block
+    {
+        return Block::make('custom-html')
+            ->label('Custom HTML')
+            ->schema([
+                Textarea::make('html')
+                    ->label('HTML Code')
+                    ->rows(10)
+                    ->required()
+                    ->helperText('Enter safe HTML. Scripts are stripped unless explicitly allowed.')
+                    ->afterStateHydrated(function ($state, callable $set, callable $get) {
+                        if ($state && ! $get('allow_scripts')) {
+                            $set('html', Purifier::clean($state));
+                        }
+                    })
+                    ->dehydrateStateUsing(function ($state, $get) {
+                        $config = $get('allow_scripts') ? 'default_allow_scripts' : null;
+
+                        return Purifier::clean($state, $config);
+                    }),
+
+                Toggle::make('allow_scripts')
+                    ->label('Allow <script> tags (Unsafe)')
+                    ->helperText('⚠️ Allowing scripts can create security vulnerabilities. Only enable if you trust the content.')
+                    ->default(false),
+
+                Toggle::make('use_container')
+                    ->label('Wrap in Bootstrap Container')
+                    ->default(true),
+
+                Select::make('background')
+                    ->label('Background Color')
+                    ->options([
+                        'none' => 'None',
+                        'bg-light' => 'Light',
+                        'bg-dark text-white' => 'Dark',
+                        'bg-primary text-white' => 'Primary',
+                        'bg-secondary' => 'Secondary',
+                    ])
+                    ->default('none'),
+
+                Select::make('padding')
+                    ->label('Padding')
+                    ->options([
+                        'py-0' => 'No Padding',
+                        'py-3' => 'Small (py-3)',
+                        'py-5' => 'Medium (py-5)',
+                        'py-7' => 'Large (py-7)',
+                    ])
+                    ->default('py-5'),
+            ]);
+    }
+
+    public static function mutateData(array $data): array
+    {
+        return [
+            'html' => $data['html'] ?? '',
+            'use_container' => $data['use_container'] ?? false,
+            'background' => $data['background'] ?? 'none',
+            'padding' => $data['padding'] ?? 'py-0',
+        ];
+    }
+}

--- a/app/Filament/Fabricator/PageBlocks/MarkdownBlock.php
+++ b/app/Filament/Fabricator/PageBlocks/MarkdownBlock.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Filament\Fabricator\PageBlocks;
+
+use Filament\Forms\Components\Builder\Block;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea as SimpleTextarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Z3d0X\FilamentFabricator\PageBlocks\PageBlock;
+
+class MarkdownBlock extends PageBlock
+{
+    public static function getBlockSchema(): Block
+    {
+        return Block::make('markdown')
+            ->label('Markdown Block')
+            ->schema([
+                SimpleTextarea::make('markdown')
+                    ->label('Markdown Content')
+                    ->rows(10)
+                    ->required(),
+
+                Select::make('editor_height')
+                    ->label('Editor Size')
+                    ->options([
+                        'small' => 'Small (5 rows)',
+                        'medium' => 'Medium (10 rows)',
+                        'large' => 'Large (20 rows)',
+                    ])
+                    ->default('medium'),
+
+                TextInput::make('custom_class')
+                    ->label('Custom CSS Class')
+                    ->nullable(),
+
+                Toggle::make('show_preview')
+                    ->label('Enable Live Preview')
+                    ->default(true),
+
+                Toggle::make('allow_unsafe_html')
+                    ->label('Allow Unsafe HTML (Potentially Dangerous)')
+                    ->helperText('Only enable if you trust the content fully.')
+                    ->default(false),
+            ]);
+    }
+
+    public static function mutateData(array $data): array
+    {
+        return [
+            'markdown' => $data['markdown'] ?? '',
+            'customClass' => $data['custom_class'] ?? '',
+            'showPreview' => $data['show_preview'] ?? false,
+            'editorHeight' => $data['editor_height'] ?? 'medium',
+            'allowUnsafe' => $data['allow_unsafe_html'] ?? false,
+        ];
+    }
+}

--- a/app/Filament/Fabricator/PageBlocks/MarkdownBlock.php
+++ b/app/Filament/Fabricator/PageBlocks/MarkdownBlock.php
@@ -3,8 +3,7 @@
 namespace App\Filament\Fabricator\PageBlocks;
 
 use Filament\Forms\Components\Builder\Block;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Components\Textarea as SimpleTextarea;
+use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Z3d0X\FilamentFabricator\PageBlocks\PageBlock;
@@ -16,19 +15,9 @@ class MarkdownBlock extends PageBlock
         return Block::make('markdown')
             ->label('Markdown Block')
             ->schema([
-                SimpleTextarea::make('markdown')
+                MarkdownEditor::make('markdown')
                     ->label('Markdown Content')
-                    ->rows(10)
                     ->required(),
-
-                Select::make('editor_height')
-                    ->label('Editor Size')
-                    ->options([
-                        'small' => 'Small (5 rows)',
-                        'medium' => 'Medium (10 rows)',
-                        'large' => 'Large (20 rows)',
-                    ])
-                    ->default('medium'),
 
                 TextInput::make('custom_class')
                     ->label('Custom CSS Class')
@@ -51,7 +40,6 @@ class MarkdownBlock extends PageBlock
             'markdown' => $data['markdown'] ?? '',
             'customClass' => $data['custom_class'] ?? '',
             'showPreview' => $data['show_preview'] ?? false,
-            'editorHeight' => $data['editor_height'] ?? 'medium',
             'allowUnsafe' => $data['allow_unsafe_html'] ?? false,
         ];
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,8 +8,10 @@ use App\Services\TwitchService;
 use App\Utilities\CartHelper;
 use App\Utilities\ShopHelper;
 use App\Utilities\StreamHelper;
+use App\View\Helpers\ViewHelpers;
 use Exception;
 use Filament\FilamentManager;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Spatie\Health\Checks\Checks\DebugModeCheck;
 use Spatie\Health\Checks\Checks\EnvironmentCheck;
@@ -44,6 +46,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        Blade::if('filament', function () {
+            return ViewHelpers::isFilament();
+        });
+
         Health::checks([
             OptimizedAppCheck::new(),
             DebugModeCheck::new(),

--- a/app/View/Helpers/ViewHelpers.php
+++ b/app/View/Helpers/ViewHelpers.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\View\Helpers;
+
+class ViewHelpers
+{
+    public static function isFilament(): bool
+    {
+        return request()->is('admin/*') || str_starts_with(request()->route()?->getName(), 'filament.');
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1464,12 +1464,12 @@
             "version": "2.6.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/blade-ui-kit/blade-heroicons.git",
+                "url": "https://github.com/driesvints/blade-heroicons.git",
                 "reference": "4553b2a1f6c76f0ac7f3bc0de4c0cfa06a097d19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/blade-ui-kit/blade-heroicons/zipball/4553b2a1f6c76f0ac7f3bc0de4c0cfa06a097d19",
+                "url": "https://api.github.com/repos/driesvints/blade-heroicons/zipball/4553b2a1f6c76f0ac7f3bc0de4c0cfa06a097d19",
                 "reference": "4553b2a1f6c76f0ac7f3bc0de4c0cfa06a097d19",
                 "shasum": ""
             },
@@ -1513,8 +1513,8 @@
                 "laravel"
             ],
             "support": {
-                "issues": "https://github.com/blade-ui-kit/blade-heroicons/issues",
-                "source": "https://github.com/blade-ui-kit/blade-heroicons/tree/2.6.0"
+                "issues": "https://github.com/driesvints/blade-heroicons/issues",
+                "source": "https://github.com/driesvints/blade-heroicons/tree/2.6.0"
             },
             "funding": [
                 {
@@ -1533,12 +1533,12 @@
             "version": "1.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/blade-ui-kit/blade-icons.git",
+                "url": "https://github.com/driesvints/blade-icons.git",
                 "reference": "7b743f27476acb2ed04cb518213d78abe096e814"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/blade-ui-kit/blade-icons/zipball/7b743f27476acb2ed04cb518213d78abe096e814",
+                "url": "https://api.github.com/repos/driesvints/blade-icons/zipball/7b743f27476acb2ed04cb518213d78abe096e814",
                 "reference": "7b743f27476acb2ed04cb518213d78abe096e814",
                 "shasum": ""
             },
@@ -3468,16 +3468,16 @@
         },
         {
             "name": "filament/actions",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/actions.git",
-                "reference": "38e913c5f108a2ec96c99b7b670f05ed288191e6"
+                "reference": "b99b705713719c3138d7666df56ca405c9ca8a8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/actions/zipball/38e913c5f108a2ec96c99b7b670f05ed288191e6",
-                "reference": "38e913c5f108a2ec96c99b7b670f05ed288191e6",
+                "url": "https://api.github.com/repos/filamentphp/actions/zipball/b99b705713719c3138d7666df56ca405c9ca8a8e",
+                "reference": "b99b705713719c3138d7666df56ca405c9ca8a8e",
                 "shasum": ""
             },
             "require": {
@@ -3517,20 +3517,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-04-07T10:06:29+00:00"
+            "time": "2025-04-18T12:09:52+00:00"
         },
         {
             "name": "filament/filament",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/panels.git",
-                "reference": "6c8cb5f34f83fe44e767403a41745f7617f096c1"
+                "reference": "fc22157f9f2d154ae653434495f252e04b2cb390"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/panels/zipball/6c8cb5f34f83fe44e767403a41745f7617f096c1",
-                "reference": "6c8cb5f34f83fe44e767403a41745f7617f096c1",
+                "url": "https://api.github.com/repos/filamentphp/panels/zipball/fc22157f9f2d154ae653434495f252e04b2cb390",
+                "reference": "fc22157f9f2d154ae653434495f252e04b2cb390",
                 "shasum": ""
             },
             "require": {
@@ -3582,20 +3582,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-04-07T10:06:14+00:00"
+            "time": "2025-04-18T12:09:56+00:00"
         },
         {
             "name": "filament/forms",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/forms.git",
-                "reference": "a3c9bbedfaa91b44b728365cf66f2adef7c346db"
+                "reference": "78f56bfa8685cd2d2ba554ed2d6e761a0b589118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/forms/zipball/a3c9bbedfaa91b44b728365cf66f2adef7c346db",
-                "reference": "a3c9bbedfaa91b44b728365cf66f2adef7c346db",
+                "url": "https://api.github.com/repos/filamentphp/forms/zipball/78f56bfa8685cd2d2ba554ed2d6e761a0b589118",
+                "reference": "78f56bfa8685cd2d2ba554ed2d6e761a0b589118",
                 "shasum": ""
             },
             "require": {
@@ -3638,20 +3638,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-04-07T10:06:19+00:00"
+            "time": "2025-04-19T15:33:35+00:00"
         },
         {
             "name": "filament/infolists",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/infolists.git",
-                "reference": "521db58c1555bcaefcdbf11789b949f6a2da18e5"
+                "reference": "d6cd5934aff207dcfcdec540fca92db849eeded3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/521db58c1555bcaefcdbf11789b949f6a2da18e5",
-                "reference": "521db58c1555bcaefcdbf11789b949f6a2da18e5",
+                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/d6cd5934aff207dcfcdec540fca92db849eeded3",
+                "reference": "d6cd5934aff207dcfcdec540fca92db849eeded3",
                 "shasum": ""
             },
             "require": {
@@ -3689,11 +3689,11 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-04-07T10:06:03+00:00"
+            "time": "2025-04-18T12:10:08+00:00"
         },
         {
             "name": "filament/notifications",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/notifications.git",
@@ -3745,7 +3745,7 @@
         },
         {
             "name": "filament/spatie-laravel-media-library-plugin",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-media-library-plugin.git",
@@ -3782,7 +3782,7 @@
         },
         {
             "name": "filament/spatie-laravel-settings-plugin",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-settings-plugin.git",
@@ -3829,7 +3829,7 @@
         },
         {
             "name": "filament/spatie-laravel-tags-plugin",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-tags-plugin.git",
@@ -3866,7 +3866,7 @@
         },
         {
             "name": "filament/spatie-laravel-translatable-plugin",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-translatable-plugin.git",
@@ -3911,16 +3911,16 @@
         },
         {
             "name": "filament/support",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/support.git",
-                "reference": "fbe203104322d83dedb7da0422db0779a063f165"
+                "reference": "ca955875a0e1c67aba92a1b5bb86841dd9f9ec43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/support/zipball/fbe203104322d83dedb7da0422db0779a063f165",
-                "reference": "fbe203104322d83dedb7da0422db0779a063f165",
+                "url": "https://api.github.com/repos/filamentphp/support/zipball/ca955875a0e1c67aba92a1b5bb86841dd9f9ec43",
+                "reference": "ca955875a0e1c67aba92a1b5bb86841dd9f9ec43",
                 "shasum": ""
             },
             "require": {
@@ -3966,20 +3966,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-04-07T10:58:23+00:00"
+            "time": "2025-04-18T12:09:53+00:00"
         },
         {
             "name": "filament/tables",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/tables.git",
-                "reference": "e668fea3f698019ff528d857c326620c2a71288b"
+                "reference": "e361761990eda562f874c68cc2aaec04c97d43ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/tables/zipball/e668fea3f698019ff528d857c326620c2a71288b",
-                "reference": "e668fea3f698019ff528d857c326620c2a71288b",
+                "url": "https://api.github.com/repos/filamentphp/tables/zipball/e361761990eda562f874c68cc2aaec04c97d43ba",
+                "reference": "e361761990eda562f874c68cc2aaec04c97d43ba",
                 "shasum": ""
             },
             "require": {
@@ -4018,11 +4018,11 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-04-07T10:06:35+00:00"
+            "time": "2025-04-19T15:33:35+00:00"
         },
         {
             "name": "filament/widgets",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/widgets.git",
@@ -4391,16 +4391,16 @@
         },
         {
             "name": "google/auth",
-            "version": "v1.46.0",
+            "version": "v1.47.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "7fafae99a41984cbfb92508174263cf7bf3049b9"
+                "reference": "d6389aae7c009daceaa8da9b7942d8df6969f6d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/7fafae99a41984cbfb92508174263cf7bf3049b9",
-                "reference": "7fafae99a41984cbfb92508174263cf7bf3049b9",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/d6389aae7c009daceaa8da9b7942d8df6969f6d9",
+                "reference": "d6389aae7c009daceaa8da9b7942d8df6969f6d9",
                 "shasum": ""
             },
             "require": {
@@ -4446,9 +4446,9 @@
             "support": {
                 "docs": "https://cloud.google.com/php/docs/reference/auth/latest",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.46.0"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.47.0"
             },
-            "time": "2025-02-12T22:21:37+00:00"
+            "time": "2025-04-15T21:47:20+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -5690,16 +5690,16 @@
         },
         {
             "name": "lakm/laravel-comments",
-            "version": "2.3.0",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Lakshan-Madushanka/laravel-comments.git",
-                "reference": "b47e18d5aa27e5d8fd4c270bbb91cc950b4070e6"
+                "reference": "c8da0069824e8b9c19bec9870ad06a241b89bfa0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Lakshan-Madushanka/laravel-comments/zipball/b47e18d5aa27e5d8fd4c270bbb91cc950b4070e6",
-                "reference": "b47e18d5aa27e5d8fd4c270bbb91cc950b4070e6",
+                "url": "https://api.github.com/repos/Lakshan-Madushanka/laravel-comments/zipball/c8da0069824e8b9c19bec9870ad06a241b89bfa0",
+                "reference": "c8da0069824e8b9c19bec9870ad06a241b89bfa0",
                 "shasum": ""
             },
             "require": {
@@ -5753,7 +5753,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Lakshan-Madushanka/laravel-comments/issues",
-                "source": "https://github.com/Lakshan-Madushanka/laravel-comments/tree/2.3.0"
+                "source": "https://github.com/Lakshan-Madushanka/laravel-comments/tree/2.3.1"
             },
             "funding": [
                 {
@@ -5761,7 +5761,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-06T11:58:40+00:00"
+            "time": "2025-04-18T12:31:04+00:00"
         },
         {
             "name": "lakm/nopass",
@@ -6159,16 +6159,16 @@
         },
         {
             "name": "laravel/horizon",
-            "version": "v5.31.1",
+            "version": "v5.31.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/horizon.git",
-                "reference": "bc98b63313b2e0a3d0c8e84e1b691388ef1bf653"
+                "reference": "e6068c65be6c02a01e34531abf3143fab91f0de0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/horizon/zipball/bc98b63313b2e0a3d0c8e84e1b691388ef1bf653",
-                "reference": "bc98b63313b2e0a3d0c8e84e1b691388ef1bf653",
+                "url": "https://api.github.com/repos/laravel/horizon/zipball/e6068c65be6c02a01e34531abf3143fab91f0de0",
+                "reference": "e6068c65be6c02a01e34531abf3143fab91f0de0",
                 "shasum": ""
             },
             "require": {
@@ -6233,9 +6233,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/horizon/issues",
-                "source": "https://github.com/laravel/horizon/tree/v5.31.1"
+                "source": "https://github.com/laravel/horizon/tree/v5.31.2"
             },
-            "time": "2025-03-16T23:48:25+00:00"
+            "time": "2025-04-18T12:57:39+00:00"
         },
         {
             "name": "laravel/jetstream",
@@ -6529,16 +6529,16 @@
         },
         {
             "name": "laravel/sanctum",
-            "version": "v4.0.8",
+            "version": "v4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sanctum.git",
-                "reference": "ec1dd9ddb2ab370f79dfe724a101856e0963f43c"
+                "reference": "4e4ced5023e9d8949214e0fb43d9f4bde79c7166"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sanctum/zipball/ec1dd9ddb2ab370f79dfe724a101856e0963f43c",
-                "reference": "ec1dd9ddb2ab370f79dfe724a101856e0963f43c",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/4e4ced5023e9d8949214e0fb43d9f4bde79c7166",
+                "reference": "4e4ced5023e9d8949214e0fb43d9f4bde79c7166",
                 "shasum": ""
             },
             "require": {
@@ -6589,7 +6589,7 @@
                 "issues": "https://github.com/laravel/sanctum/issues",
                 "source": "https://github.com/laravel/sanctum"
             },
-            "time": "2025-01-26T19:34:36+00:00"
+            "time": "2025-04-22T13:53:47+00:00"
         },
         {
             "name": "laravel/scout",
@@ -6735,16 +6735,16 @@
         },
         {
             "name": "laravel/socialite",
-            "version": "v5.19.0",
+            "version": "v5.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/socialite.git",
-                "reference": "c40f843c5643fb6b089e46ce9794b8408bf08319"
+                "reference": "30972c12a41f71abeb418bc9ff157da8d9231519"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/socialite/zipball/c40f843c5643fb6b089e46ce9794b8408bf08319",
-                "reference": "c40f843c5643fb6b089e46ce9794b8408bf08319",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/30972c12a41f71abeb418bc9ff157da8d9231519",
+                "reference": "30972c12a41f71abeb418bc9ff157da8d9231519",
                 "shasum": ""
             },
             "require": {
@@ -6803,7 +6803,7 @@
                 "issues": "https://github.com/laravel/socialite/issues",
                 "source": "https://github.com/laravel/socialite"
             },
-            "time": "2025-03-27T17:26:42+00:00"
+            "time": "2025-04-21T14:21:34+00:00"
         },
         {
             "name": "laravel/telescope",
@@ -7005,16 +7005,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "d990688c91cedfb69753ffc2512727ec646df2ad"
+                "reference": "06c3b0bf2540338094575612f4a1778d0d2d5e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d990688c91cedfb69753ffc2512727ec646df2ad",
-                "reference": "d990688c91cedfb69753ffc2512727ec646df2ad",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/06c3b0bf2540338094575612f4a1778d0d2d5e94",
+                "reference": "06c3b0bf2540338094575612f4a1778d0d2d5e94",
                 "shasum": ""
             },
             "require": {
@@ -7108,7 +7108,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-29T14:10:59+00:00"
+            "time": "2025-04-18T21:09:27+00:00"
         },
         {
             "name": "league/config",
@@ -11570,16 +11570,16 @@
         },
         {
             "name": "schmeits/filament-character-counter",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmeits/filament-character-counter.git",
-                "reference": "5a6dbeaea71e019cd3aa4d01e4a0e7804272292d"
+                "reference": "b79a27696541b1c5b6ceefe10c518d0621dba8f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmeits/filament-character-counter/zipball/5a6dbeaea71e019cd3aa4d01e4a0e7804272292d",
-                "reference": "5a6dbeaea71e019cd3aa4d01e4a0e7804272292d",
+                "url": "https://api.github.com/repos/schmeits/filament-character-counter/zipball/b79a27696541b1c5b6ceefe10c518d0621dba8f0",
+                "reference": "b79a27696541b1c5b6ceefe10c518d0621dba8f0",
                 "shasum": ""
             },
             "require": {
@@ -11648,7 +11648,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-10T08:42:50+00:00"
+            "time": "2025-04-16T14:43:18+00:00"
         },
         {
             "name": "shieldon/event-dispatcher",
@@ -13577,16 +13577,16 @@
         },
         {
             "name": "spatie/laravel-health",
-            "version": "1.34.0",
+            "version": "1.34.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-health.git",
-                "reference": "f3d7c5e19569d83e4c37f7a5e249187a96ab8aa8"
+                "reference": "283d7d5dffeeff6452c9a182f466c327fec6db3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-health/zipball/f3d7c5e19569d83e4c37f7a5e249187a96ab8aa8",
-                "reference": "f3d7c5e19569d83e4c37f7a5e249187a96ab8aa8",
+                "url": "https://api.github.com/repos/spatie/laravel-health/zipball/283d7d5dffeeff6452c9a182f466c327fec6db3b",
+                "reference": "283d7d5dffeeff6452c9a182f466c327fec6db3b",
                 "shasum": ""
             },
             "require": {
@@ -13658,7 +13658,7 @@
                 "spatie"
             ],
             "support": {
-                "source": "https://github.com/spatie/laravel-health/tree/1.34.0"
+                "source": "https://github.com/spatie/laravel-health/tree/1.34.1"
             },
             "funding": [
                 {
@@ -13666,7 +13666,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-01T13:22:01+00:00"
+            "time": "2025-04-17T06:34:01+00:00"
         },
         {
             "name": "spatie/laravel-honeypot",
@@ -15121,16 +15121,16 @@
         },
         {
             "name": "stephenjude/filament-feature-flags",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stephenjude/filament-feature-flags.git",
-                "reference": "4441fd4463e77ad731d395090f2835fdde34bf30"
+                "reference": "40d6c9cb8daa2871686e2f0a4c374df7364c3b44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stephenjude/filament-feature-flags/zipball/4441fd4463e77ad731d395090f2835fdde34bf30",
-                "reference": "4441fd4463e77ad731d395090f2835fdde34bf30",
+                "url": "https://api.github.com/repos/stephenjude/filament-feature-flags/zipball/40d6c9cb8daa2871686e2f0a4c374df7364c3b44",
+                "reference": "40d6c9cb8daa2871686e2f0a4c374df7364c3b44",
                 "shasum": ""
             },
             "require": {
@@ -15183,9 +15183,9 @@
             ],
             "support": {
                 "issues": "https://github.com/stephenjude/filament-feature-flags/issues",
-                "source": "https://github.com/stephenjude/filament-feature-flags/tree/3.0.1"
+                "source": "https://github.com/stephenjude/filament-feature-flags/tree/3.0.2"
             },
-            "time": "2025-03-31T19:49:10+00:00"
+            "time": "2025-04-16T10:52:42+00:00"
         },
         {
             "name": "stephenjude/filament-jetstream",
@@ -18054,16 +18054,16 @@
         },
         {
             "name": "tomatophp/filament-icons",
-            "version": "v1.1.4",
+            "version": "v1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tomatophp/filament-icons.git",
-                "reference": "fd9cd3d0741bb286a833f390e723f4d8f4004f27"
+                "reference": "38339344651e3624b2eb9c7c5e42a2addb35a81b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tomatophp/filament-icons/zipball/fd9cd3d0741bb286a833f390e723f4d8f4004f27",
-                "reference": "fd9cd3d0741bb286a833f390e723f4d8f4004f27",
+                "url": "https://api.github.com/repos/tomatophp/filament-icons/zipball/38339344651e3624b2eb9c7c5e42a2addb35a81b",
+                "reference": "38339344651e3624b2eb9c7c5e42a2addb35a81b",
                 "shasum": ""
             },
             "require": {
@@ -18107,7 +18107,7 @@
             ],
             "support": {
                 "issues": "https://github.com/tomatophp/filament-icons/issues",
-                "source": "https://github.com/tomatophp/filament-icons/tree/v1.1.4"
+                "source": "https://github.com/tomatophp/filament-icons/tree/v1.1.5"
             },
             "funding": [
                 {
@@ -18115,20 +18115,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-08T14:08:00+00:00"
+            "time": "2025-04-16T04:44:30+00:00"
         },
         {
             "name": "tomatophp/filament-media-manager",
-            "version": "v1.1.3",
+            "version": "v1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tomatophp/filament-media-manager.git",
-                "reference": "357de7e0ee1beaf11a7b591232114b68f716db76"
+                "reference": "b16d1d02ff6de40c8bfcf3c96a8e257a328e86ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tomatophp/filament-media-manager/zipball/357de7e0ee1beaf11a7b591232114b68f716db76",
-                "reference": "357de7e0ee1beaf11a7b591232114b68f716db76",
+                "url": "https://api.github.com/repos/tomatophp/filament-media-manager/zipball/b16d1d02ff6de40c8bfcf3c96a8e257a328e86ed",
+                "reference": "b16d1d02ff6de40c8bfcf3c96a8e257a328e86ed",
                 "shasum": ""
             },
             "require": {
@@ -18174,7 +18174,7 @@
             ],
             "support": {
                 "issues": "https://github.com/tomatophp/filament-media-manager/issues",
-                "source": "https://github.com/tomatophp/filament-media-manager/tree/v1.1.3"
+                "source": "https://github.com/tomatophp/filament-media-manager/tree/v1.1.4"
             },
             "funding": [
                 {
@@ -18182,7 +18182,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-17T16:51:09+00:00"
+            "time": "2025-04-16T04:38:15+00:00"
         },
         {
             "name": "tomatophp/filament-menus",
@@ -18876,16 +18876,16 @@
     "packages-dev": [
         {
             "name": "barryvdh/laravel-debugbar",
-            "version": "v3.15.3",
+            "version": "v3.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/barryvdh/laravel-debugbar.git",
-                "reference": "4ccab20844d18c5af08b68d310e7151a791c3037"
+                "reference": "c0667ea91f7185f1e074402c5788195e96bf8106"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/4ccab20844d18c5af08b68d310e7151a791c3037",
-                "reference": "4ccab20844d18c5af08b68d310e7151a791c3037",
+                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/c0667ea91f7185f1e074402c5788195e96bf8106",
+                "reference": "c0667ea91f7185f1e074402c5788195e96bf8106",
                 "shasum": ""
             },
             "require": {
@@ -18945,7 +18945,7 @@
             ],
             "support": {
                 "issues": "https://github.com/barryvdh/laravel-debugbar/issues",
-                "source": "https://github.com/barryvdh/laravel-debugbar/tree/v3.15.3"
+                "source": "https://github.com/barryvdh/laravel-debugbar/tree/v3.15.4"
             },
             "funding": [
                 {
@@ -18957,7 +18957,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-08T15:11:06+00:00"
+            "time": "2025-04-16T06:32:06+00:00"
         },
         {
             "name": "barryvdh/laravel-ide-helper",
@@ -19699,16 +19699,16 @@
         },
         {
             "name": "larastan/larastan",
-            "version": "v3.3.1",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/larastan/larastan.git",
-                "reference": "58bee8be51daf12d78ed0a909be3b205607d2f27"
+                "reference": "1042fa0c2ee490bb6da7381f3323f7292ad68222"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/58bee8be51daf12d78ed0a909be3b205607d2f27",
-                "reference": "58bee8be51daf12d78ed0a909be3b205607d2f27",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/1042fa0c2ee490bb6da7381f3323f7292ad68222",
+                "reference": "1042fa0c2ee490bb6da7381f3323f7292ad68222",
                 "shasum": ""
             },
             "require": {
@@ -19725,7 +19725,7 @@
                 "phpstan/phpstan": "^2.1.11"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^12.0",
+                "doctrine/coding-standard": "^13",
                 "laravel/framework": "^11.44.2 || ^12.7.2",
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.4",
@@ -19761,13 +19761,9 @@
                 {
                     "name": "Can Vural",
                     "email": "can9119@gmail.com"
-                },
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
                 }
             ],
-            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan wrapper for Laravel",
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
             "keywords": [
                 "PHPStan",
                 "code analyse",
@@ -19780,19 +19776,15 @@
             ],
             "support": {
                 "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v3.3.1"
+                "source": "https://github.com/larastan/larastan/tree/v3.4.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/canvural",
                     "type": "github"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
                 }
             ],
-            "time": "2025-04-03T20:08:04+00:00"
+            "time": "2025-04-22T09:44:59+00:00"
         },
         {
             "name": "laravel/pail",
@@ -19940,16 +19932,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.41.0",
+            "version": "v1.41.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "fe1a4ada0abb5e4bd99eb4e4b0d87906c00cdeec"
+                "reference": "e5692510f1ef8e0f5096cde2b885d558f8d86592"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/fe1a4ada0abb5e4bd99eb4e4b0d87906c00cdeec",
-                "reference": "fe1a4ada0abb5e4bd99eb4e4b0d87906c00cdeec",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/e5692510f1ef8e0f5096cde2b885d558f8d86592",
+                "reference": "e5692510f1ef8e0f5096cde2b885d558f8d86592",
                 "shasum": ""
             },
             "require": {
@@ -19999,7 +19991,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2025-01-24T15:45:36+00:00"
+            "time": "2025-04-22T13:39:39+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -20245,16 +20237,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v3.8.1",
+            "version": "v3.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "6080f51a0b0830715c48ba0e7458b06907febfe5"
+                "reference": "c6244a8712968dbac88eb998e7ff3b5caa556b0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/6080f51a0b0830715c48ba0e7458b06907febfe5",
-                "reference": "6080f51a0b0830715c48ba0e7458b06907febfe5",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/c6244a8712968dbac88eb998e7ff3b5caa556b0d",
+                "reference": "c6244a8712968dbac88eb998e7ff3b5caa556b0d",
                 "shasum": ""
             },
             "require": {
@@ -20341,7 +20333,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v3.8.1"
+                "source": "https://github.com/pestphp/pest/tree/v3.8.2"
             },
             "funding": [
                 {
@@ -20353,7 +20345,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-03T16:35:58+00:00"
+            "time": "2025-04-17T10:53:02+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -20427,16 +20419,16 @@
         },
         {
             "name": "pestphp/pest-plugin-arch",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest-plugin-arch.git",
-                "reference": "ebec636b97ee73936ee8485e15a59c3f5a4c21b2"
+                "reference": "db7bd9cb1612b223e16618d85475c6f63b9c8daa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/ebec636b97ee73936ee8485e15a59c3f5a4c21b2",
-                "reference": "ebec636b97ee73936ee8485e15a59c3f5a4c21b2",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/db7bd9cb1612b223e16618d85475c6f63b9c8daa",
+                "reference": "db7bd9cb1612b223e16618d85475c6f63b9c8daa",
                 "shasum": ""
             },
             "require": {
@@ -20445,7 +20437,7 @@
                 "ta-tikoma/phpunit-architecture-test": "^0.8.4"
             },
             "require-dev": {
-                "pestphp/pest": "^3.7.5",
+                "pestphp/pest": "^3.8.1",
                 "pestphp/pest-dev-tools": "^3.4.0"
             },
             "type": "library",
@@ -20481,7 +20473,7 @@
                 "unit"
             ],
             "support": {
-                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v3.1.0"
+                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -20493,7 +20485,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-30T17:28:50+00:00"
+            "time": "2025-04-16T22:59:48+00:00"
         },
         {
             "name": "pestphp/pest-plugin-mutate",
@@ -20757,16 +20749,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.11",
+            "version": "2.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "8ca5f79a8f63c49b2359065832a654e1ec70ac30"
+                "reference": "96dde49e967c0c22812bcfa7bda4ff82c09f3b0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8ca5f79a8f63c49b2359065832a654e1ec70ac30",
-                "reference": "8ca5f79a8f63c49b2359065832a654e1ec70ac30",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/96dde49e967c0c22812bcfa7bda4ff82c09f3b0c",
+                "reference": "96dde49e967c0c22812bcfa7bda4ff82c09f3b0c",
                 "shasum": ""
             },
             "require": {
@@ -20811,7 +20803,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-24T13:45:00+00:00"
+            "time": "2025-04-16T13:19:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -21243,12 +21235,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "508576e5d70b881870043c666e3e4081b474d23f"
+                "reference": "4a535062396cc0a0bb7a6bc72e4dc15e8b2018d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/508576e5d70b881870043c666e3e4081b474d23f",
-                "reference": "508576e5d70b881870043c666e3e4081b474d23f",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/4a535062396cc0a0bb7a6bc72e4dc15e8b2018d0",
+                "reference": "4a535062396cc0a0bb7a6bc72e4dc15e8b2018d0",
                 "shasum": ""
             },
             "conflict": {
@@ -21475,7 +21467,7 @@
                 "firebase/php-jwt": "<6",
                 "fisharebest/webtrees": "<=2.1.18",
                 "fixpunkt/fp-masterquiz": "<2.2.1|>=3,<3.5.2",
-                "fixpunkt/fp-newsletter": "<1.1.1|>=2,<2.1.2|>=2.2,<3.2.6",
+                "fixpunkt/fp-newsletter": "<1.1.1|>=1.2,<2.1.2|>=2.2,<3.2.6",
                 "flarum/core": "<1.8.10",
                 "flarum/flarum": "<0.1.0.0-beta8",
                 "flarum/framework": "<1.8.10",
@@ -21755,6 +21747,7 @@
                 "pear/archive_tar": "<1.4.14",
                 "pear/auth": "<1.2.4",
                 "pear/crypt_gpg": "<1.6.7",
+                "pear/http_request2": "<2.7",
                 "pear/pear": "<=1.10.1",
                 "pegasus/google-for-jobs": "<1.5.1|>=2,<2.1.1",
                 "personnummer/personnummer": "<3.0.2",
@@ -22161,7 +22154,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-14T20:05:54+00:00"
+            "time": "2025-04-21T23:05:07+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -23215,23 +23208,23 @@
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
-            "version": "0.8.4",
+            "version": "0.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
-                "reference": "89f0dea1cb0f0d5744d3ec1764a286af5e006636"
+                "reference": "cf6fb197b676ba716837c886baca842e4db29005"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/89f0dea1cb0f0d5744d3ec1764a286af5e006636",
-                "reference": "89f0dea1cb0f0d5744d3ec1764a286af5e006636",
+                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/cf6fb197b676ba716837c886baca842e4db29005",
+                "reference": "cf6fb197b676ba716837c886baca842e4db29005",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18.0 || ^5.0.0",
                 "php": "^8.1.0",
                 "phpdocumentor/reflection-docblock": "^5.3.0",
-                "phpunit/phpunit": "^10.5.5  || ^11.0.0",
+                "phpunit/phpunit": "^10.5.5  || ^11.0.0 || ^12.0.0",
                 "symfony/finder": "^6.4.0 || ^7.0.0"
             },
             "require-dev": {
@@ -23268,9 +23261,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
-                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.4"
+                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.5"
             },
-            "time": "2024-01-05T14:10:56+00:00"
+            "time": "2025-04-20T20:23:40+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Ok, glad you are here
+ * first we get a config instance, and set the settings
+ * $config = HTMLPurifier_Config::createDefault();
+ * $config->set('Core.Encoding', $this->config->get('purifier.encoding'));
+ * $config->set('Cache.SerializerPath', $this->config->get('purifier.cachePath'));
+ * if ( ! $this->config->get('purifier.finalize')) {
+ *     $config->autoFinalize = false;
+ * }
+ * $config->loadArray($this->getConfig());
+ *
+ * You must NOT delete the default settings
+ * anything in settings should be compacted with params that needed to instance HTMLPurifier_Config.
+ *
+ * @link http://htmlpurifier.org/live/configdoc/plain.html
+ */
+
+return [
+    'encoding' => 'UTF-8',
+    'finalize' => true,
+    'ignoreNonStrings' => false,
+    'cachePath' => storage_path('app/purifier'),
+    'cacheFileMode' => 0755,
+    'settings' => [
+        'default' => [
+            'HTML.Doctype' => 'HTML 4.01 Transitional',
+            'HTML.Allowed' => 'div,b,strong,i,em,u,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src]',
+            'HTML.SafeIframe' => 'true',
+            'URI.SafeIframeRegexp' => '%^(http://|https://|//)(www.youtube.com/embed/|player.vimeo.com/video/)%',
+            'CSS.AllowedProperties' => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
+            'AutoFormat.AutoParagraph' => true,
+            'AutoFormat.RemoveEmpty' => true,
+        ],
+        'default_allow_scripts' => [
+            'HTML.Doctype' => 'HTML 4.01 Transitional',
+            'HTML.Allowed' => '*[*]', // Allow everything (DANGEROUS, be careful)
+            'CSS.AllowedProperties' => '*[*]',
+            'AutoFormat.AutoParagraph' => true,
+            'AutoFormat.RemoveEmpty' => true,
+        ],
+        'test' => [
+            'Attr.EnableID' => 'true',
+        ],
+        'youtube' => [
+            'HTML.SafeIframe' => 'true',
+            'URI.SafeIframeRegexp' => '%^(http://|https://|//)(www.youtube.com/embed/|player.vimeo.com/video/)%',
+        ],
+        'custom_definition' => [
+            'id' => 'html5-definitions',
+            'rev' => 1,
+            'debug' => false,
+            'elements' => [
+                // http://developers.whatwg.org/sections.html
+                ['section', 'Block', 'Flow', 'Common'],
+                ['nav', 'Block', 'Flow', 'Common'],
+                ['article', 'Block', 'Flow', 'Common'],
+                ['aside', 'Block', 'Flow', 'Common'],
+                ['header', 'Block', 'Flow', 'Common'],
+                ['footer', 'Block', 'Flow', 'Common'],
+
+                // Content model actually excludes several tags, not modelled here
+                ['address', 'Block', 'Flow', 'Common'],
+                ['hgroup', 'Block', 'Required: h1 | h2 | h3 | h4 | h5 | h6', 'Common'],
+
+                // http://developers.whatwg.org/grouping-content.html
+                ['figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common'],
+                ['figcaption', 'Inline', 'Flow', 'Common'],
+
+                // http://developers.whatwg.org/the-video-element.html#the-video-element
+                ['video', 'Block', 'Optional: (source, Flow) | (Flow, source) | Flow', 'Common', [
+                    'src' => 'URI',
+                    'type' => 'Text',
+                    'width' => 'Length',
+                    'height' => 'Length',
+                    'poster' => 'URI',
+                    'preload' => 'Enum#auto,metadata,none',
+                    'controls' => 'Bool',
+                ]],
+                ['source', 'Block', 'Flow', 'Common', [
+                    'src' => 'URI',
+                    'type' => 'Text',
+                ]],
+
+                // http://developers.whatwg.org/text-level-semantics.html
+                ['s', 'Inline', 'Inline', 'Common'],
+                ['var', 'Inline', 'Inline', 'Common'],
+                ['sub', 'Inline', 'Inline', 'Common'],
+                ['sup', 'Inline', 'Inline', 'Common'],
+                ['mark', 'Inline', 'Inline', 'Common'],
+                ['wbr', 'Inline', 'Empty', 'Core'],
+
+                // http://developers.whatwg.org/edits.html
+                ['ins', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],
+                ['del', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],
+            ],
+            'attributes' => [
+                ['iframe', 'allowfullscreen', 'Bool'],
+                ['table', 'height', 'Text'],
+                ['td', 'border', 'Text'],
+                ['th', 'border', 'Text'],
+                ['tr', 'width', 'Text'],
+                ['tr', 'height', 'Text'],
+                ['tr', 'border', 'Text'],
+            ],
+        ],
+        'custom_attributes' => [
+            ['a', 'target', 'Enum#_blank,_self,_target,_top'],
+        ],
+        'custom_elements' => [
+            ['u', 'Inline', 'Inline', 'Common'],
+        ],
+    ],
+
+];

--- a/public/js/guava/tutorials/components/step.js
+++ b/public/js/guava/tutorials/components/step.js
@@ -1,231 +1,315 @@
 // resources/js/components/step.js
-function stepComponent({
-                           key,
-                           selector,
-                           shouldInterceptClick,
-                           interceptClickAction
+function stepComponent ({
+  key,
+  selector,
+  shouldInterceptClick,
+  interceptClickAction
 }) {
-    return {
-        target: null,
-        sleep: function (ms) {
-            return new Promise((resolve) => setTimeout(resolve, ms));
-        },
-        init: async function () {
-            this.target = this.findElement(key);
-            if (!this.target) {
-                console.error("Tutorial step was not found:", key);
-                return;
-            }
-            document.documentElement.querySelectorAll("input").forEach((element) => element.blur());
-            if (this.target) {
-                this.target.focus();
-            }
-            this.configure();
-            const dialog = this.$el.querySelector("[data-dialog]");
-            const clipPath = this.$el.querySelector("[data-clip-path]");
-            if (shouldInterceptClick) {
-                this.target.addEventListener("click", (event) => {
-                    event.preventDefault();
-                    this.$wire.call(interceptClickAction);
-                    this.target.blur();
-                    const descendants = this.target.querySelectorAll(":hover");
-                    for (let i = 0; i < descendants.length; i++) {
-                        const descendant = descendants[i];
-                        descendant.blur();
-                    }
-                });
-            }
-            this.initializeDialog();
-            this.$nextTick(() => {
-                clipPath.setAttribute("d", this.clipPath());
-                this.$dispatch("tutorial::render");
-            });
-            clipPath.setAttribute("d", this.clipPath());
-        },
-        timeouts: [],
-        configure: function () {
-            document.addEventListener("keydown", function (event) {
-                var key2 = event.key;
-                var isShiftKey = event.shiftKey;
-                var isCtrlKey = false;
-                var isAltKey = false;
-                if (key2 === "Tab") {
-                    event.preventDefault();
-                }
-            });
-            if (this.target instanceof HTMLSelectElement) {
-                if (this.target.hasAttribute("data-choice")) {
-                    this.target = this.target.parentElement.parentElement;
-                    const dropdown = this.target.querySelector(".choices__list.choices__list--dropdown");
-                    dropdown.style.zIndex = 100;
-                }
-            }
-            if (this.target.tagName === "TRIX-EDITOR") {
-                this.timeouts["trix"] = this.target.clientHeight;
-                this.target = this.target.parentElement;
-                const observer = new MutationObserver((mutationsList, observer2) => {
-                    mutationsList.forEach((mutation) => {
-                        if (this.timeouts["trix"]) {
-                            clearTimeout(this.timeouts["trix"]);
-                        }
-                        this.timeouts["trix"] = setTimeout(() => {
-                            this.timeouts["trix"] = null;
-                            this.init();
-                        }, 500);
-                    });
-                });
-                const config = {
-                    attributes: true,
-                    attributeFilter: ["height"],
-                    childList: true,
-                    subtree: true
-                };
-                observer.observe(this.target, config);
-            }
-            if (this.target instanceof HTMLTextAreaElement || this.t) {
-                let initialWidth = this.target.offsetWidth;
-                let initialHeight = this.target.offsetHeight;
-                const observer = new MutationObserver(() => {
-                    if (this.target.offsetWidth !== initialWidth || this.target.offsetHeight !== initialHeight) {
-                        initialWidth = this.target.offsetWidth;
-                        initialHeight = this.target.offsetHeight;
-                        if (this.timeouts["textarea"]) {
-                            clearTimeout(this.timeouts["textarea"]);
-                        }
-                        this.timeouts["textarea"] = setTimeout(() => {
-                            this.timeouts["textarea"] = null;
-                            this.init();
-                        }, 100);
-                    }
-                });
-                observer.observe(this.target, {attributes: true, attributeFilter: ["style"]});
-            }
-        },
-        // You can define any other Alpine.js functions here.
-        initializeDialog: function (dialog = null) {
-            if (!dialog) {
-                dialog = this.$el.querySelector("[data-dialog]");
-            }
-            const dialogPath = dialog.querySelector("[data-dialog-path]");
-            const rect = this.elementRect();
-            const stroke = dialog.querySelector("[data-dialog-stroke]");
-            window.scrollTo({
-                top: rect[0].y - window.innerHeight / 3,
-                left: rect[0].x,
-                behavior: "smooth"
-            });
-            const width = rect[1].x - rect[0].x;
-            const height = rect[2].y - rect[0].y;
-            const x = rect[0].x;
-            const y = rect[0].y;
-            dialog.style.width = `${width}px`;
-            dialog.style.transform = `translate(${x}px, ${y}px)`;
-            stroke.style.height = `${height}px`;
-            dialogPath.setAttribute("d", this.elementPath(null, {relative: true, positive: true}));
-        },
-        clipPath: function (element = null, options = {}) {
-            element = element || this.target;
-            options = {
-                radius: 24,
-                margin: 10,
-                offset: {x: 0, y: 0},
-                relative: false,
-                ...options
-            };
-            return `${this.windowPath()} ${this.elementPath(element, options)}`.trim();
-        },
-        windowPath: function () {
-            const documentHeight = Math.max(
-                document.documentElement.clientHeight,
-                document.documentElement.scrollHeight,
-                document.documentElement.offsetHeight
-            );
-            let path = "M 0 0 ";
-            path += "L 0 " + documentHeight + " ";
-            path += "L " + window.innerWidth + " " + documentHeight + " ";
-            path += "L " + window.innerWidth + " 0 ";
-            path += "L 0 0 ";
-            return path.trim();
-        },
-        findElement: function (name) {
-            return document.querySelector(selector.replace(/\./g, "\\$&")) ?? document.querySelector(selector);
-        },
-        elementPath: function (element = null, options = {}) {
-            element = element || this.target;
-            options = {
-                radius: 24,
-                margin: 10,
-                offset: {x: 0, y: 0},
-                ...options
-            };
-            const rect = this.elementRect(element, {
-                relative: false,
-                ...options
-            });
-            let path = "";
-            path += "M " + rect[0].x + " " + (rect[0].y + options.radius) + " ";
-            path += "C " + rect[0].x + " " + rect[0].y + " " + rect[0].x + " " + rect[0].y + " " + (rect[0].x + options.radius) + " " + rect[0].y + " ";
-            path += "L " + (rect[1].x - options.radius) + " " + rect[1].y + " ";
-            path += "C " + rect[1].x + " " + rect[1].y + " " + rect[1].x + " " + rect[1].y + " " + rect[1].x + " " + (rect[1].y + options.radius) + " ";
-            path += "L " + rect[2].x + " " + (rect[2].y - options.radius) + " ";
-            path += "C " + rect[2].x + " " + rect[2].y + " " + rect[2].x + " " + rect[2].y + " " + (rect[2].x - options.radius) + " " + rect[2].y + " ";
-            path += "L " + (rect[3].x + options.radius) + " " + rect[3].y + " ";
-            path += "C " + rect[3].x + " " + rect[3].y + " " + rect[3].x + " " + rect[3].y + " " + rect[3].x + " " + (rect[3].y - options.radius) + " ";
-            path += "L " + rect[0].x + " " + (rect[0].y + options.radius) + " ";
-            return path.trim();
-        },
-        elementRect: function (element = null, options = {}) {
-            element = element || this.target;
-            const bounds = element.getBoundingClientRect();
-            options = {
-                radius: 24,
-                margin: 10,
-                offset: {x: 0, y: 0},
-                relative: false,
-                ...options
-            };
-            const left = options.relative ? 0 : bounds.left;
-            const top = options.relative ? 0 : element.offsetTop;
-            let result = [
-                {
-                    x: left - options.margin + options.offset.x,
-                    y: top - options.margin + options.offset.y
-                },
-                {
-                    x: left + element.clientWidth + options.margin + options.offset.x,
-                    y: top - options.margin + options.offset.y
-                },
-                {
-                    x: left + element.clientWidth + options.margin + options.offset.x,
-                    y: top + element.clientHeight + options.margin + options.offset.y
-                },
-                {
-                    x: left - options.margin + options.offset.x,
-                    y: top + element.clientHeight + options.margin + options.offset.y
-                }
-            ];
-            if (options.positive) {
-                let minX = 0;
-                let minY = 0;
-                for (let i = 0; i < result.length; i++) {
-                    if (result[i].x < minX) {
-                        minX = result[i].x;
-                    }
-                    if (result[i].y < minY) {
-                        minY = result[i].y;
-                    }
-                }
-                for (let i = 0; i < result.length; i++) {
-                    result[i].x -= minX;
-                    result[i].y -= minY;
-                }
-            }
-            return result;
+  return {
+    target: null,
+    sleep: function (ms) {
+      return new Promise((resolve) => setTimeout(resolve, ms))
+    },
+    init: async function () {
+      this.target = this.findElement(key)
+      if (!this.target) {
+        console.error('Tutorial step was not found:', key)
+        return
+      }
+      document.documentElement
+        .querySelectorAll('input')
+        .forEach((element) => element.blur())
+      if (this.target) {
+        this.target.focus()
+      }
+      this.configure()
+      const dialog = this.$el.querySelector('[data-dialog]')
+      const clipPath = this.$el.querySelector('[data-clip-path]')
+      if (shouldInterceptClick) {
+        this.target.addEventListener('click', (event) => {
+          event.preventDefault()
+          this.$wire.call(interceptClickAction)
+          this.target.blur()
+          const descendants = this.target.querySelectorAll(':hover')
+          for (let i = 0; i < descendants.length; i++) {
+            const descendant = descendants[i]
+            descendant.blur()
+          }
+        })
+      }
+      this.initializeDialog()
+      this.$nextTick(() => {
+        clipPath.setAttribute('d', this.clipPath())
+        this.$dispatch('tutorial::render')
+      })
+      clipPath.setAttribute('d', this.clipPath())
+    },
+    timeouts: [],
+    configure: function () {
+      document.addEventListener('keydown', function (event) {
+        const key2 = event.key
+        const isShiftKey = event.shiftKey
+        const isCtrlKey = false
+        const isAltKey = false
+        if (key2 === 'Tab') {
+          event.preventDefault()
         }
-    };
+      })
+      if (this.target instanceof HTMLSelectElement) {
+        if (this.target.hasAttribute('data-choice')) {
+          this.target = this.target.parentElement.parentElement
+          const dropdown = this.target.querySelector(
+            '.choices__list.choices__list--dropdown'
+          )
+          dropdown.style.zIndex = 100
+        }
+      }
+      if (this.target.tagName === 'TRIX-EDITOR') {
+        this.timeouts.trix = this.target.clientHeight
+        this.target = this.target.parentElement
+        const observer = new MutationObserver(
+          (mutationsList, observer2) => {
+            mutationsList.forEach((mutation) => {
+              if (this.timeouts.trix) {
+                clearTimeout(this.timeouts.trix)
+              }
+              this.timeouts.trix = setTimeout(() => {
+                this.timeouts.trix = null
+                this.init()
+              }, 500)
+            })
+          }
+        )
+        const config = {
+          attributes: true,
+          attributeFilter: ['height'],
+          childList: true,
+          subtree: true
+        }
+        observer.observe(this.target, config)
+      }
+      if (this.target instanceof HTMLTextAreaElement || this.t) {
+        let initialWidth = this.target.offsetWidth
+        let initialHeight = this.target.offsetHeight
+        const observer = new MutationObserver(() => {
+          if (
+            this.target.offsetWidth !== initialWidth ||
+                        this.target.offsetHeight !== initialHeight
+          ) {
+            initialWidth = this.target.offsetWidth
+            initialHeight = this.target.offsetHeight
+            if (this.timeouts.textarea) {
+              clearTimeout(this.timeouts.textarea)
+            }
+            this.timeouts.textarea = setTimeout(() => {
+              this.timeouts.textarea = null
+              this.init()
+            }, 100)
+          }
+        })
+        observer.observe(this.target, {
+          attributes: true,
+          attributeFilter: ['style']
+        })
+      }
+    },
+    // You can define any other Alpine.js functions here.
+    initializeDialog: function (dialog = null) {
+      if (!dialog) {
+        dialog = this.$el.querySelector('[data-dialog]')
+      }
+      const dialogPath = dialog.querySelector('[data-dialog-path]')
+      const rect = this.elementRect()
+      const stroke = dialog.querySelector('[data-dialog-stroke]')
+      window.scrollTo({
+        top: rect[0].y - window.innerHeight / 3,
+        left: rect[0].x,
+        behavior: 'smooth'
+      })
+      const width = rect[1].x - rect[0].x
+      const height = rect[2].y - rect[0].y
+      const x = rect[0].x
+      const y = rect[0].y
+      dialog.style.width = `${width}px`
+      dialog.style.transform = `translate(${x}px, ${y}px)`
+      stroke.style.height = `${height}px`
+      dialogPath.setAttribute(
+        'd',
+        this.elementPath(null, { relative: true, positive: true })
+      )
+    },
+    clipPath: function (element = null, options = {}) {
+      element = element || this.target
+      options = {
+        radius: 24,
+        margin: 10,
+        offset: { x: 0, y: 0 },
+        relative: false,
+        ...options
+      }
+      return `${this.windowPath()} ${this.elementPath(element, options)}`.trim()
+    },
+    windowPath: function () {
+      const documentHeight = Math.max(
+        document.documentElement.clientHeight,
+        document.documentElement.scrollHeight,
+        document.documentElement.offsetHeight
+      )
+      let path = 'M 0 0 '
+      path += 'L 0 ' + documentHeight + ' '
+      path += 'L ' + window.innerWidth + ' ' + documentHeight + ' '
+      path += 'L ' + window.innerWidth + ' 0 '
+      path += 'L 0 0 '
+      return path.trim()
+    },
+    findElement: function (name) {
+      return (
+        document.querySelector(selector.replace(/\./g, '\\$&')) ??
+                document.querySelector(selector)
+      )
+    },
+    elementPath: function (element = null, options = {}) {
+      element = element || this.target
+      options = {
+        radius: 24,
+        margin: 10,
+        offset: { x: 0, y: 0 },
+        ...options
+      }
+      const rect = this.elementRect(element, {
+        relative: false,
+        ...options
+      })
+      let path = ''
+      path += 'M ' + rect[0].x + ' ' + (rect[0].y + options.radius) + ' '
+      path +=
+                'C ' +
+                rect[0].x +
+                ' ' +
+                rect[0].y +
+                ' ' +
+                rect[0].x +
+                ' ' +
+                rect[0].y +
+                ' ' +
+                (rect[0].x + options.radius) +
+                ' ' +
+                rect[0].y +
+                ' '
+      path += 'L ' + (rect[1].x - options.radius) + ' ' + rect[1].y + ' '
+      path +=
+                'C ' +
+                rect[1].x +
+                ' ' +
+                rect[1].y +
+                ' ' +
+                rect[1].x +
+                ' ' +
+                rect[1].y +
+                ' ' +
+                rect[1].x +
+                ' ' +
+                (rect[1].y + options.radius) +
+                ' '
+      path += 'L ' + rect[2].x + ' ' + (rect[2].y - options.radius) + ' '
+      path +=
+                'C ' +
+                rect[2].x +
+                ' ' +
+                rect[2].y +
+                ' ' +
+                rect[2].x +
+                ' ' +
+                rect[2].y +
+                ' ' +
+                (rect[2].x - options.radius) +
+                ' ' +
+                rect[2].y +
+                ' '
+      path += 'L ' + (rect[3].x + options.radius) + ' ' + rect[3].y + ' '
+      path +=
+                'C ' +
+                rect[3].x +
+                ' ' +
+                rect[3].y +
+                ' ' +
+                rect[3].x +
+                ' ' +
+                rect[3].y +
+                ' ' +
+                rect[3].x +
+                ' ' +
+                (rect[3].y - options.radius) +
+                ' '
+      path += 'L ' + rect[0].x + ' ' + (rect[0].y + options.radius) + ' '
+      return path.trim()
+    },
+    elementRect: function (element = null, options = {}) {
+      element = element || this.target
+      const bounds = element.getBoundingClientRect()
+      options = {
+        radius: 24,
+        margin: 10,
+        offset: { x: 0, y: 0 },
+        relative: false,
+        ...options
+      }
+      const left = options.relative ? 0 : bounds.left
+      const top = options.relative ? 0 : element.offsetTop
+      const result = [
+        {
+          x: left - options.margin + options.offset.x,
+          y: top - options.margin + options.offset.y
+        },
+        {
+          x:
+                        left +
+                        element.clientWidth +
+                        options.margin +
+                        options.offset.x,
+          y: top - options.margin + options.offset.y
+        },
+        {
+          x:
+                        left +
+                        element.clientWidth +
+                        options.margin +
+                        options.offset.x,
+          y:
+                        top +
+                        element.clientHeight +
+                        options.margin +
+                        options.offset.y
+        },
+        {
+          x: left - options.margin + options.offset.x,
+          y:
+                        top +
+                        element.clientHeight +
+                        options.margin +
+                        options.offset.y
+        }
+      ]
+      if (options.positive) {
+        let minX = 0
+        let minY = 0
+        for (let i = 0; i < result.length; i++) {
+          if (result[i].x < minX) {
+            minX = result[i].x
+          }
+          if (result[i].y < minY) {
+            minY = result[i].y
+          }
+        }
+        for (let i = 0; i < result.length; i++) {
+          result[i].x -= minX
+          result[i].y -= minY
+        }
+      }
+      return result
+    }
+  }
 }
 
-export {
-    stepComponent as default
-};
-//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vY29tcG9uZW50cy9zdGVwLmpzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJleHBvcnQgZGVmYXVsdCBmdW5jdGlvbiBzdGVwQ29tcG9uZW50KHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGtleSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHNlbGVjdG9yLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgc2hvdWxkSW50ZXJjZXB0Q2xpY2ssXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpbnRlcmNlcHRDbGlja0FjdGlvbixcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgfSkge1xuICAgIHJldHVybiB7XG4gICAgICAgIHRhcmdldDogbnVsbCxcblxuICAgICAgICBzbGVlcDogZnVuY3Rpb24gKG1zKSB7XG4gICAgICAgICAgICByZXR1cm4gbmV3IFByb21pc2UocmVzb2x2ZSA9PiBzZXRUaW1lb3V0KHJlc29sdmUsIG1zKSk7XG4gICAgICAgIH0sXG5cbiAgICAgICAgaW5pdDogYXN5bmMgZnVuY3Rpb24gKCkge1xuICAgICAgICAgICAgdGhpcy50YXJnZXQgPSB0aGlzLmZpbmRFbGVtZW50KGtleSk7XG5cbiAgICAgICAgICAgIGlmICghdGhpcy50YXJnZXQpIHtcbiAgICAgICAgICAgICAgICBjb25zb2xlLmVycm9yKCdUdXRvcmlhbCBzdGVwIHdhcyBub3QgZm91bmQ6Jywga2V5KTtcbiAgICAgICAgICAgICAgICByZXR1cm47XG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIC8vIHdpbmRvdy5ibHVyKCk7XG4gICAgICAgICAgICAvLyBkb2N1bWVudC5kb2N1bWVudEVsZW1lbnQuYmx1cigpO1xuICAgICAgICAgICAgZG9jdW1lbnQuZG9jdW1lbnRFbGVtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJ2lucHV0JylcbiAgICAgICAgICAgICAgICAuZm9yRWFjaCgoZWxlbWVudCkgPT4gZWxlbWVudC5ibHVyKCkpO1xuICAgICAgICAgICAgaWYgKHRoaXMudGFyZ2V0KSB7XG4gICAgICAgICAgICAgICAgdGhpcy50YXJnZXQuZm9jdXMoKTtcbiAgICAgICAgICAgIH1cblxuICAgICAgICAgICAgdGhpcy5jb25maWd1cmUoKTtcblxuICAgICAgICAgICAgY29uc3QgZGlhbG9nID0gdGhpcy4kZWwucXVlcnlTZWxlY3RvcignW2RhdGEtZGlhbG9nXScpO1xuICAgICAgICAgICAgY29uc3QgY2xpcFBhdGggPSB0aGlzLiRlbC5xdWVyeVNlbGVjdG9yKCdbZGF0YS1jbGlwLXBhdGhdJyk7XG5cbiAgICAgICAgICAgIGlmIChzaG91bGRJbnRlcmNlcHRDbGljaykge1xuICAgICAgICAgICAgICAgIHRoaXMudGFyZ2V0LmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKGV2ZW50KSA9PiB7XG4gICAgICAgICAgICAgICAgICAgIGV2ZW50LnByZXZlbnREZWZhdWx0KCk7XG4gICAgICAgICAgICAgICAgICAgIHRoaXMuJHdpcmUuY2FsbChpbnRlcmNlcHRDbGlja0FjdGlvbik7XG5cbiAgICAgICAgICAgICAgICAgICAgdGhpcy50YXJnZXQuYmx1cigpO1xuICAgICAgICAgICAgICAgICAgICBjb25zdCBkZXNjZW5kYW50cyA9IHRoaXMudGFyZ2V0LnF1ZXJ5U2VsZWN0b3JBbGwoXCI6aG92ZXJcIik7XG5cbiAgICAgICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCBkZXNjZW5kYW50cy5sZW5ndGg7IGkrKykge1xuICAgICAgICAgICAgICAgICAgICAgICAgY29uc3QgZGVzY2VuZGFudCA9IGRlc2NlbmRhbnRzW2ldO1xuICAgICAgICAgICAgICAgICAgICAgICAgZGVzY2VuZGFudC5ibHVyKCk7XG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICB9KTtcbiAgICAgICAgICAgIH1cblxuICAgICAgICAgICAgdGhpcy5pbml0aWFsaXplRGlhbG9nKCk7XG5cbiAgICAgICAgICAgIHRoaXMuJG5leHRUaWNrKCgpID0+IHtcbiAgICAgICAgICAgICAgICBjbGlwUGF0aC5zZXRBdHRyaWJ1dGUoJ2QnLCB0aGlzLmNsaXBQYXRoKCkpO1xuICAgICAgICAgICAgICAgIHRoaXMuJGRpc3BhdGNoKCd0dXRvcmlhbDo6cmVuZGVyJyk7XG4gICAgICAgICAgICB9KTtcblxuICAgICAgICAgICAgY2xpcFBhdGguc2V0QXR0cmlidXRlKCdkJywgdGhpcy5jbGlwUGF0aCgpKTtcbiAgICAgICAgfSxcblxuICAgICAgICB0aW1lb3V0czogW10sXG5cbiAgICAgICAgY29uZmlndXJlOiBmdW5jdGlvbiAoKSB7XG4gICAgICAgICAgICBkb2N1bWVudC5hZGRFdmVudExpc3RlbmVyKCdrZXlkb3duJywgZnVuY3Rpb24gKGV2ZW50KSB7XG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBrZXkgY29kZSBvZiB0aGUga2V5IHByZXNzZWRcbiAgICAgICAgICAgICAgICB2YXIga2V5ID0gZXZlbnQua2V5O1xuXG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBzdGF0ZSBvZiB0aGUgbW9kaWZpZXIga2V5c1xuICAgICAgICAgICAgICAgIC8vIHZhciBpc0N0cmxLZXkgPSBldmVudC5jdHJsS2V5IHx8IGV2ZW50Lm1ldGFLZXk7XG4gICAgICAgICAgICAgICAgLy8gdmFyIGlzQWx0S2V5ID0gZXZlbnQuYWx0S2V5O1xuICAgICAgICAgICAgICAgIHZhciBpc1NoaWZ0S2V5ID0gZXZlbnQuc2hpZnRLZXk7XG4gICAgICAgICAgICAgICAgdmFyIGlzQ3RybEtleSA9IGZhbHNlO1xuICAgICAgICAgICAgICAgIHZhciBpc0FsdEtleSA9IGZhbHNlO1xuXG4gICAgICAgICAgICAgICAgLy8gQ2hlY2sgaWYgYW55IGNvbWJpbmF0aW9uIG9mIG1vZGlmaWVyIGtleXMgYW5kIG5vcm1hbCBrZXlzIHdlcmUgcHJlc3NlZFxuICAgICAgICAgICAgICAgIC8vIGlmIChpc0N0cmxLZXkgfHwgaXNBbHRLZXkgfHwgaXNTaGlmdEtleSB8fCBrZXkgPT09ICdUYWInKSB7XG4gICAgICAgICAgICAgICAgLy8gaWYgKGtleSA9PT0gJ1RhYicgfHwgaXNTaGlmdEtleSAmJiBrZXkgPT09ICdUYWInKSB7XG4gICAgICAgICAgICAgICAgaWYgKGtleSA9PT0gJ1RhYicpIHtcbiAgICAgICAgICAgICAgICAgICAgZXZlbnQucHJldmVudERlZmF1bHQoKTsgLy8gUHJldmVudCB0aGUgZGVmYXVsdCBldmVudCBiZWhhdmlvclxuICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgIH0pO1xuXG5cbiAgICAgICAgICAgIGlmICh0aGlzLnRhcmdldCBpbnN0YW5jZW9mIEhUTUxTZWxlY3RFbGVtZW50KSB7XG4gICAgICAgICAgICAgICAgaWYgKHRoaXMudGFyZ2V0Lmhhc0F0dHJpYnV0ZSgnZGF0YS1jaG9pY2UnKSkge1xuICAgICAgICAgICAgICAgICAgICB0aGlzLnRhcmdldCA9IHRoaXMudGFyZ2V0LnBhcmVudEVsZW1lbnQucGFyZW50RWxlbWVudDtcbiAgICAgICAgICAgICAgICAgICAgY29uc3QgZHJvcGRvd24gPSB0aGlzLnRhcmdldC5xdWVyeVNlbGVjdG9yKCcuY2hvaWNlc19fbGlzdC5jaG9pY2VzX19saXN0LS1kcm9wZG93bicpO1xuICAgICAgICAgICAgICAgICAgICBkcm9wZG93bi5zdHlsZS56SW5kZXggPSAxMDA7XG4gICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICBpZiAodGhpcy50YXJnZXQudGFnTmFtZSA9PT0gJ1RSSVgtRURJVE9SJykge1xuICAgICAgICAgICAgICAgIHRoaXMudGltZW91dHNbJ3RyaXgnXSA9IHRoaXMudGFyZ2V0LmNsaWVudEhlaWdodDtcbiAgICAgICAgICAgICAgICB0aGlzLnRhcmdldCA9IHRoaXMudGFyZ2V0LnBhcmVudEVsZW1lbnQ7XG5cbiAgICAgICAgICAgICAgICBjb25zdCBvYnNlcnZlciA9IG5ldyBNdXRhdGlvbk9ic2VydmVyKChtdXRhdGlvbnNMaXN0LCBvYnNlcnZlcikgPT4ge1xuXG4gICAgICAgICAgICAgICAgICAgIG11dGF0aW9uc0xpc3QuZm9yRWFjaCgobXV0YXRpb24pID0+IHtcblxuICAgICAgICAgICAgICAgICAgICAgICAgaWYgKHRoaXMudGltZW91dHNbJ3RyaXgnXSkge1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNsZWFyVGltZW91dCh0aGlzLnRpbWVvdXRzWyd0cml4J10pO1xuICAgICAgICAgICAgICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0cml4J10gPSBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0cml4J10gPSBudWxsO1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMuaW5pdCgpO1xuICAgICAgICAgICAgICAgICAgICAgICAgfSwgNTAwKTtcbiAgICAgICAgICAgICAgICAgICAgfSk7XG4gICAgICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgICAgICBjb25zdCBjb25maWcgPSB7XG4gICAgICAgICAgICAgICAgICAgIGF0dHJpYnV0ZXM6IHRydWUsXG4gICAgICAgICAgICAgICAgICAgIGF0dHJpYnV0ZUZpbHRlcjogWydoZWlnaHQnXSxcbiAgICAgICAgICAgICAgICAgICAgY2hpbGRMaXN0OiB0cnVlLFxuICAgICAgICAgICAgICAgICAgICBzdWJ0cmVlOiB0cnVlLFxuICAgICAgICAgICAgICAgIH07XG5cbiAgICAgICAgICAgICAgICBvYnNlcnZlci5vYnNlcnZlKHRoaXMudGFyZ2V0LCBjb25maWcpO1xuXG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIGlmICh0aGlzLnRhcmdldCBpbnN0YW5jZW9mIEhUTUxUZXh0QXJlYUVsZW1lbnQgfHwgdGhpcy50KSB7XG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBpbml0aWFsIHNpemUgb2YgdGhlIHRleHRhcmVhXG4gICAgICAgICAgICAgICAgbGV0IGluaXRpYWxXaWR0aCA9IHRoaXMudGFyZ2V0Lm9mZnNldFdpZHRoO1xuICAgICAgICAgICAgICAgIGxldCBpbml0aWFsSGVpZ2h0ID0gdGhpcy50YXJnZXQub2Zmc2V0SGVpZ2h0O1xuXG4gICAgICAgICAgICAgICAgLy8gQ3JlYXRlIGEgTXV0YXRpb25PYnNlcnZlciB0byBtb25pdG9yIHNpemUgY2hhbmdlc1xuICAgICAgICAgICAgICAgIGNvbnN0IG9ic2VydmVyID0gbmV3IE11dGF0aW9uT2JzZXJ2ZXIoKCkgPT4ge1xuICAgICAgICAgICAgICAgICAgICBpZiAodGhpcy50YXJnZXQub2Zmc2V0V2lkdGggIT09IGluaXRpYWxXaWR0aCB8fCB0aGlzLnRhcmdldC5vZmZzZXRIZWlnaHQgIT09IGluaXRpYWxIZWlnaHQpIHtcbiAgICAgICAgICAgICAgICAgICAgICAgIGluaXRpYWxXaWR0aCA9IHRoaXMudGFyZ2V0Lm9mZnNldFdpZHRoO1xuICAgICAgICAgICAgICAgICAgICAgICAgaW5pdGlhbEhlaWdodCA9IHRoaXMudGFyZ2V0Lm9mZnNldEhlaWdodDtcblxuICAgICAgICAgICAgICAgICAgICAgICAgaWYgKHRoaXMudGltZW91dHNbJ3RleHRhcmVhJ10pIHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICBjbGVhclRpbWVvdXQodGhpcy50aW1lb3V0c1sndGV4dGFyZWEnXSk7XG4gICAgICAgICAgICAgICAgICAgICAgICB9XG5cbiAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMudGltZW91dHNbJ3RleHRhcmVhJ10gPSBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0ZXh0YXJlYSddID0gbnVsbDtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLmluaXQoKTtcbiAgICAgICAgICAgICAgICAgICAgICAgIH0sIDEwMCk7XG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICB9KTtcblxuICAgICAgICAgICAgICAgIC8vIFN0YXJ0IG9ic2VydmluZyBjaGFuZ2VzIGluIHRoZSB0ZXh0YXJlYSBlbGVtZW50XG4gICAgICAgICAgICAgICAgb2JzZXJ2ZXIub2JzZXJ2ZSh0aGlzLnRhcmdldCwge2F0dHJpYnV0ZXM6IHRydWUsIGF0dHJpYnV0ZUZpbHRlcjogWydzdHlsZSddfSk7XG4gICAgICAgICAgICB9XG4gICAgICAgIH0sXG4gICAgICAgIC8vIFlvdSBjYW4gZGVmaW5lIGFueSBvdGhlciBBbHBpbmUuanMgZnVuY3Rpb25zIGhlcmUuXG5cbiAgICAgICAgaW5pdGlhbGl6ZURpYWxvZzogZnVuY3Rpb24gKGRpYWxvZyA9IG51bGwpIHtcbiAgICAgICAgICAgIGlmICghZGlhbG9nKSB7XG4gICAgICAgICAgICAgICAgZGlhbG9nID0gdGhpcy4kZWwucXVlcnlTZWxlY3RvcignW2RhdGEtZGlhbG9nXScpO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgZGlhbG9nUGF0aCA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCdbZGF0YS1kaWFsb2ctcGF0aF0nKTtcblxuICAgICAgICAgICAgY29uc3QgcmVjdCA9IHRoaXMuZWxlbWVudFJlY3QoKTtcbiAgICAgICAgICAgIC8vIGNvbnN0IGhlYWRlciA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCdbZGF0YS1kaWFsb2ctaGVhZGVyXScpO1xuICAgICAgICAgICAgY29uc3Qgc3Ryb2tlID0gZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJ1tkYXRhLWRpYWxvZy1zdHJva2VdJyk7XG5cbiAgICAgICAgICAgIHdpbmRvdy5zY3JvbGxUbyh7XG4gICAgICAgICAgICAgICAgdG9wOiByZWN0WzBdLnkgLSAod2luZG93LmlubmVySGVpZ2h0IC8gMyksXG4gICAgICAgICAgICAgICAgbGVmdDogcmVjdFswXS54LFxuICAgICAgICAgICAgICAgIGJlaGF2aW9yOiAnc21vb3RoJ1xuICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgIGNvbnN0IHdpZHRoID0gcmVjdFsxXS54IC0gcmVjdFswXS54O1xuICAgICAgICAgICAgY29uc3QgaGVpZ2h0ID0gcmVjdFsyXS55IC0gcmVjdFswXS55O1xuXG4gICAgICAgICAgICBjb25zdCB4ID0gcmVjdFswXS54O1xuICAgICAgICAgICAgY29uc3QgeSA9IHJlY3RbMF0ueTtcbiAgICAgICAgICAgIGRpYWxvZy5zdHlsZS53aWR0aCA9IGAke3dpZHRofXB4YDtcbiAgICAgICAgICAgIGRpYWxvZy5zdHlsZS50cmFuc2Zvcm0gPSBgdHJhbnNsYXRlKCR7eH1weCwgJHt5fXB4KWA7XG4gICAgICAgICAgICBzdHJva2Uuc3R5bGUuaGVpZ2h0ID0gYCR7aGVpZ2h0fXB4YDtcblxuICAgICAgICAgICAgZGlhbG9nUGF0aC5zZXRBdHRyaWJ1dGUoJ2QnLCB0aGlzLmVsZW1lbnRQYXRoKG51bGwsIHtyZWxhdGl2ZTogdHJ1ZSwgcG9zaXRpdmU6IHRydWV9KSlcbiAgICAgICAgfSxcblxuICAgICAgICBjbGlwUGF0aDogZnVuY3Rpb24gKGVsZW1lbnQgPSBudWxsLCBvcHRpb25zID0ge30pIHtcbiAgICAgICAgICAgIGVsZW1lbnQgPSBlbGVtZW50IHx8IHRoaXMudGFyZ2V0O1xuICAgICAgICAgICAgb3B0aW9ucyA9IHtcbiAgICAgICAgICAgICAgICByYWRpdXM6IDI0LFxuICAgICAgICAgICAgICAgIG1hcmdpbjogMTAsXG4gICAgICAgICAgICAgICAgb2Zmc2V0OiB7eDogMCwgeTogMH0sXG4gICAgICAgICAgICAgICAgcmVsYXRpdmU6IGZhbHNlLFxuICAgICAgICAgICAgICAgIC4uLm9wdGlvbnNcbiAgICAgICAgICAgIH1cbiAgICAgICAgICAgIHJldHVybiBgJHt0aGlzLndpbmRvd1BhdGgoKX0gJHt0aGlzLmVsZW1lbnRQYXRoKGVsZW1lbnQsIG9wdGlvbnMpfWAudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIHdpbmRvd1BhdGg6IGZ1bmN0aW9uICgpIHtcbiAgICAgICAgICAgIGNvbnN0IGRvY3VtZW50SGVpZ2h0ID0gTWF0aC5tYXgoXG4gICAgICAgICAgICAgICAgZG9jdW1lbnQuZG9jdW1lbnRFbGVtZW50LmNsaWVudEhlaWdodCxcbiAgICAgICAgICAgICAgICBkb2N1bWVudC5kb2N1bWVudEVsZW1lbnQuc2Nyb2xsSGVpZ2h0LFxuICAgICAgICAgICAgICAgIGRvY3VtZW50LmRvY3VtZW50RWxlbWVudC5vZmZzZXRIZWlnaHQsXG4gICAgICAgICAgICApO1xuXG4gICAgICAgICAgICAvLyBUT0RPOiBhZGQgb3B0aW9uIHRvIHNlbGVjdCBjbG9ja3dpc2UgL2NvdW50ZXIgY2xvY2t3aXNlXG4gICAgICAgICAgICAvL00gMCA4IEMgMCAwIDAgMCA4IDAgTCAzOCAwIEMgNDYgMCA0NiAwIDQ2IDggQyA0NiAxNiA0NiAxNiAzOCAxNiBMIDggMTYgQyAwIDE2IDAgMTYgMCA4XG4gICAgICAgICAgICBsZXQgcGF0aCA9ICdNIDAgMCAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAwICcgKyBkb2N1bWVudEhlaWdodCArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0wgJyArIHdpbmRvdy5pbm5lcldpZHRoICsgJyAnICsgZG9jdW1lbnRIZWlnaHQgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdMICcgKyB3aW5kb3cuaW5uZXJXaWR0aCArICcgMCAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAwIDAgJztcblxuICAgICAgICAgICAgcmV0dXJuIHBhdGgudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIGZpbmRFbGVtZW50OiBmdW5jdGlvbiAobmFtZSkge1xuICAgICAgICAgICAgcmV0dXJuIGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3Ioc2VsZWN0b3IucmVwbGFjZSgvXFwuL2csICdcXFxcJCYnKSlcbiAgICAgICAgICAgICAgICA/PyBkb2N1bWVudC5xdWVyeVNlbGVjdG9yKHNlbGVjdG9yKTtcbiAgICAgICAgfSxcblxuICAgICAgICBlbGVtZW50UGF0aDogZnVuY3Rpb24gKGVsZW1lbnQgPSBudWxsLCBvcHRpb25zID0ge30pIHtcbiAgICAgICAgICAgIGVsZW1lbnQgPSBlbGVtZW50IHx8IHRoaXMudGFyZ2V0O1xuICAgICAgICAgICAgb3B0aW9ucyA9IHtcbiAgICAgICAgICAgICAgICByYWRpdXM6IDI0LFxuICAgICAgICAgICAgICAgIG1hcmdpbjogMTAsXG4gICAgICAgICAgICAgICAgb2Zmc2V0OiB7eDogMCwgeTogMH0sXG4gICAgICAgICAgICAgICAgLi4ub3B0aW9uc1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgcmVjdCA9IHRoaXMuZWxlbWVudFJlY3QoZWxlbWVudCwge1xuICAgICAgICAgICAgICAgIHJlbGF0aXZlOiBmYWxzZSxcbiAgICAgICAgICAgICAgICAuLi5vcHRpb25zLFxuICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgIGxldCBwYXRoID0gJyc7XG4gICAgICAgICAgICBwYXRoICs9ICdNICcgKyByZWN0WzBdLnggKyAnICcgKyAocmVjdFswXS55ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnQyAnICsgcmVjdFswXS54ICsgJyAnICsgcmVjdFswXS55ICsgJyAnICsgcmVjdFswXS54ICsgJyAnICsgcmVjdFswXS55ICsgJyAnICsgKHJlY3RbMF0ueCArIG9wdGlvbnMucmFkaXVzKSArICcgJyArIHJlY3RbMF0ueSArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0wgJyArIChyZWN0WzFdLnggLSBvcHRpb25zLnJhZGl1cykgKyAnICcgKyByZWN0WzFdLnkgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdDICcgKyByZWN0WzFdLnggKyAnICcgKyByZWN0WzFdLnkgKyAnICcgKyByZWN0WzFdLnggKyAnICcgKyByZWN0WzFdLnkgKyAnICcgKyByZWN0WzFdLnggKyAnICcgKyAocmVjdFsxXS55ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAnICsgcmVjdFsyXS54ICsgJyAnICsgKHJlY3RbMl0ueSAtIG9wdGlvbnMucmFkaXVzKSArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0MgJyArIHJlY3RbMl0ueCArICcgJyArIHJlY3RbMl0ueSArICcgJyArIHJlY3RbMl0ueCArICcgJyArIHJlY3RbMl0ueSArICcgJyArIChyZWN0WzJdLnggLSBvcHRpb25zLnJhZGl1cykgKyAnICcgKyByZWN0WzJdLnkgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdMICcgKyAocmVjdFszXS54ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnICsgcmVjdFszXS55ICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnQyAnICsgcmVjdFszXS54ICsgJyAnICsgcmVjdFszXS55ICsgJyAnICsgcmVjdFszXS54ICsgJyAnICsgcmVjdFszXS55ICsgJyAnICsgcmVjdFszXS54ICsgJyAnICsgKHJlY3RbM10ueSAtIG9wdGlvbnMucmFkaXVzKSArICcgJztcbiAgICAgICAgICAgIC8vIHBhdGggKz0gJ1onO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAnICsgcmVjdFswXS54ICsgJyAnICsgKHJlY3RbMF0ueSArIG9wdGlvbnMucmFkaXVzKSArICcgJztcblxuICAgICAgICAgICAgcmV0dXJuIHBhdGgudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIGVsZW1lbnRSZWN0OiBmdW5jdGlvbiAoZWxlbWVudCA9IG51bGwsIG9wdGlvbnMgPSB7fSkge1xuXG4gICAgICAgICAgICBlbGVtZW50ID0gZWxlbWVudCB8fCB0aGlzLnRhcmdldDtcbiAgICAgICAgICAgIGNvbnN0IGJvdW5kcyA9IGVsZW1lbnQuZ2V0Qm91bmRpbmdDbGllbnRSZWN0KCk7XG4gICAgICAgICAgICBvcHRpb25zID0ge1xuICAgICAgICAgICAgICAgIHJhZGl1czogMjQsXG4gICAgICAgICAgICAgICAgbWFyZ2luOiAxMCxcbiAgICAgICAgICAgICAgICBvZmZzZXQ6IHt4OiAwLCB5OiAwfSxcbiAgICAgICAgICAgICAgICByZWxhdGl2ZTogZmFsc2UsXG4gICAgICAgICAgICAgICAgLi4ub3B0aW9uc1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgbGVmdCA9IG9wdGlvbnMucmVsYXRpdmUgPyAwIDogYm91bmRzLmxlZnQ7XG4gICAgICAgICAgICBjb25zdCB0b3AgPSBvcHRpb25zLnJlbGF0aXZlID8gMCA6IGVsZW1lbnQub2Zmc2V0VG9wO1xuXG4gICAgICAgICAgICBsZXQgcmVzdWx0ID0gW1xuICAgICAgICAgICAgICAgIHtcbiAgICAgICAgICAgICAgICAgICAgeDogbGVmdCAtIG9wdGlvbnMubWFyZ2luICsgb3B0aW9ucy5vZmZzZXQueCxcbiAgICAgICAgICAgICAgICAgICAgeTogdG9wIC0gb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfSxcbiAgICAgICAgICAgICAgICB7XG4gICAgICAgICAgICAgICAgICAgIHg6IGxlZnQgKyBlbGVtZW50LmNsaWVudFdpZHRoICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC54LFxuICAgICAgICAgICAgICAgICAgICB5OiB0b3AgLSBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LnlcbiAgICAgICAgICAgICAgICB9LFxuICAgICAgICAgICAgICAgIHtcbiAgICAgICAgICAgICAgICAgICAgeDogbGVmdCArIGVsZW1lbnQuY2xpZW50V2lkdGggKyBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LngsXG4gICAgICAgICAgICAgICAgICAgIHk6IHRvcCArIGVsZW1lbnQuY2xpZW50SGVpZ2h0ICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfSxcbiAgICAgICAgICAgICAgICB7XG4gICAgICAgICAgICAgICAgICAgIHg6IGxlZnQgLSBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LngsXG4gICAgICAgICAgICAgICAgICAgIHk6IHRvcCArIGVsZW1lbnQuY2xpZW50SGVpZ2h0ICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgXTtcblxuICAgICAgICAgICAgaWYgKG9wdGlvbnMucG9zaXRpdmUpIHtcbiAgICAgICAgICAgICAgICBsZXQgbWluWCA9IDA7XG4gICAgICAgICAgICAgICAgbGV0IG1pblkgPSAwO1xuXG4gICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCByZXN1bHQubGVuZ3RoOyBpKyspIHtcbiAgICAgICAgICAgICAgICAgICAgaWYgKHJlc3VsdFtpXS54IDwgbWluWCkge1xuICAgICAgICAgICAgICAgICAgICAgICAgbWluWCA9IHJlc3VsdFtpXS54O1xuICAgICAgICAgICAgICAgICAgICB9XG5cbiAgICAgICAgICAgICAgICAgICAgaWYgKHJlc3VsdFtpXS55IDwgbWluWSkge1xuICAgICAgICAgICAgICAgICAgICAgICAgbWluWSA9IHJlc3VsdFtpXS55O1xuICAgICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCByZXN1bHQubGVuZ3RoOyBpKyspIHtcbiAgICAgICAgICAgICAgICAgICAgcmVzdWx0W2ldLnggLT0gbWluWDtcbiAgICAgICAgICAgICAgICAgICAgcmVzdWx0W2ldLnkgLT0gbWluWTtcbiAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIHJldHVybiByZXN1bHQ7XG4gICAgICAgIH1cbiAgICB9XG59Il0sCiAgIm1hcHBpbmdzIjogIjtBQUFlLFNBQVIsY0FBK0I7QUFBQSxFQUNJO0FBQUEsRUFDQTtBQUFBLEVBQ0E7QUFBQSxFQUNBO0FBQ0osR0FBRztBQUNyQyxTQUFPO0FBQUEsSUFDSCxRQUFRO0FBQUEsSUFFUixPQUFPLFNBQVUsSUFBSTtBQUNqQixhQUFPLElBQUksUUFBUSxhQUFXLFdBQVcsU0FBUyxFQUFFLENBQUM7QUFBQSxJQUN6RDtBQUFBLElBRUEsTUFBTSxpQkFBa0I7QUFDcEIsV0FBSyxTQUFTLEtBQUssWUFBWSxHQUFHO0FBRWxDLFVBQUksQ0FBQyxLQUFLLFFBQVE7QUFDZCxnQkFBUSxNQUFNLGdDQUFnQyxHQUFHO0FBQ2pEO0FBQUEsTUFDSjtBQUlBLGVBQVMsZ0JBQWdCLGlCQUFpQixPQUFPLEVBQzVDLFFBQVEsQ0FBQyxZQUFZLFFBQVEsS0FBSyxDQUFDO0FBQ3hDLFVBQUksS0FBSyxRQUFRO0FBQ2IsYUFBSyxPQUFPLE1BQU07QUFBQSxNQUN0QjtBQUVBLFdBQUssVUFBVTtBQUVmLFlBQU0sU0FBUyxLQUFLLElBQUksY0FBYyxlQUFlO0FBQ3JELFlBQU0sV0FBVyxLQUFLLElBQUksY0FBYyxrQkFBa0I7QUFFMUQsVUFBSSxzQkFBc0I7QUFDdEIsYUFBSyxPQUFPLGlCQUFpQixTQUFTLENBQUMsVUFBVTtBQUM3QyxnQkFBTSxlQUFlO0FBQ3JCLGVBQUssTUFBTSxLQUFLLG9CQUFvQjtBQUVwQyxlQUFLLE9BQU8sS0FBSztBQUNqQixnQkFBTSxjQUFjLEtBQUssT0FBTyxpQkFBaUIsUUFBUTtBQUV6RCxtQkFBUyxJQUFJLEdBQUcsSUFBSSxZQUFZLFFBQVEsS0FBSztBQUN6QyxrQkFBTSxhQUFhLFlBQVksQ0FBQztBQUNoQyx1QkFBVyxLQUFLO0FBQUEsVUFDcEI7QUFBQSxRQUNKLENBQUM7QUFBQSxNQUNMO0FBRUEsV0FBSyxpQkFBaUI7QUFFdEIsV0FBSyxVQUFVLE1BQU07QUFDakIsaUJBQVMsYUFBYSxLQUFLLEtBQUssU0FBUyxDQUFDO0FBQzFDLGFBQUssVUFBVSxrQkFBa0I7QUFBQSxNQUNyQyxDQUFDO0FBRUQsZUFBUyxhQUFhLEtBQUssS0FBSyxTQUFTLENBQUM7QUFBQSxJQUM5QztBQUFBLElBRUEsVUFBVSxDQUFDO0FBQUEsSUFFWCxXQUFXLFdBQVk7QUFDbkIsZUFBUyxpQkFBaUIsV0FBVyxTQUFVLE9BQU87QUFFbEQsWUFBSUEsT0FBTSxNQUFNO0FBS2hCLFlBQUksYUFBYSxNQUFNO0FBQ3ZCLFlBQUksWUFBWTtBQUNoQixZQUFJLFdBQVc7QUFLZixZQUFJQSxTQUFRLE9BQU87QUFDZixnQkFBTSxlQUFlO0FBQUEsUUFDekI7QUFBQSxNQUNKLENBQUM7QUFHRCxVQUFJLEtBQUssa0JBQWtCLG1CQUFtQjtBQUMxQyxZQUFJLEtBQUssT0FBTyxhQUFhLGFBQWEsR0FBRztBQUN6QyxlQUFLLFNBQVMsS0FBSyxPQUFPLGNBQWM7QUFDeEMsZ0JBQU0sV0FBVyxLQUFLLE9BQU8sY0FBYyx3Q0FBd0M7QUFDbkYsbUJBQVMsTUFBTSxTQUFTO0FBQUEsUUFDNUI7QUFBQSxNQUNKO0FBRUEsVUFBSSxLQUFLLE9BQU8sWUFBWSxlQUFlO0FBQ3ZDLGFBQUssU0FBUyxNQUFNLElBQUksS0FBSyxPQUFPO0FBQ3BDLGFBQUssU0FBUyxLQUFLLE9BQU87QUFFMUIsY0FBTSxXQUFXLElBQUksaUJBQWlCLENBQUMsZUFBZUMsY0FBYTtBQUUvRCx3QkFBYyxRQUFRLENBQUMsYUFBYTtBQUVoQyxnQkFBSSxLQUFLLFNBQVMsTUFBTSxHQUFHO0FBQ3ZCLDJCQUFhLEtBQUssU0FBUyxNQUFNLENBQUM7QUFBQSxZQUN0QztBQUVBLGlCQUFLLFNBQVMsTUFBTSxJQUFJLFdBQVcsTUFBTTtBQUNyQyxtQkFBSyxTQUFTLE1BQU0sSUFBSTtBQUN4QixtQkFBSyxLQUFLO0FBQUEsWUFDZCxHQUFHLEdBQUc7QUFBQSxVQUNWLENBQUM7QUFBQSxRQUNMLENBQUM7QUFFRCxjQUFNLFNBQVM7QUFBQSxVQUNYLFlBQVk7QUFBQSxVQUNaLGlCQUFpQixDQUFDLFFBQVE7QUFBQSxVQUMxQixXQUFXO0FBQUEsVUFDWCxTQUFTO0FBQUEsUUFDYjtBQUVBLGlCQUFTLFFBQVEsS0FBSyxRQUFRLE1BQU07QUFBQSxNQUV4QztBQUVBLFVBQUksS0FBSyxrQkFBa0IsdUJBQXVCLEtBQUssR0FBRztBQUV0RCxZQUFJLGVBQWUsS0FBSyxPQUFPO0FBQy9CLFlBQUksZ0JBQWdCLEtBQUssT0FBTztBQUdoQyxjQUFNLFdBQVcsSUFBSSxpQkFBaUIsTUFBTTtBQUN4QyxjQUFJLEtBQUssT0FBTyxnQkFBZ0IsZ0JBQWdCLEtBQUssT0FBTyxpQkFBaUIsZUFBZTtBQUN4RiwyQkFBZSxLQUFLLE9BQU87QUFDM0IsNEJBQWdCLEtBQUssT0FBTztBQUU1QixnQkFBSSxLQUFLLFNBQVMsVUFBVSxHQUFHO0FBQzNCLDJCQUFhLEtBQUssU0FBUyxVQUFVLENBQUM7QUFBQSxZQUMxQztBQUVBLGlCQUFLLFNBQVMsVUFBVSxJQUFJLFdBQVcsTUFBTTtBQUN6QyxtQkFBSyxTQUFTLFVBQVUsSUFBSTtBQUM1QixtQkFBSyxLQUFLO0FBQUEsWUFDZCxHQUFHLEdBQUc7QUFBQSxVQUNWO0FBQUEsUUFDSixDQUFDO0FBR0QsaUJBQVMsUUFBUSxLQUFLLFFBQVEsRUFBQyxZQUFZLE1BQU0saUJBQWlCLENBQUMsT0FBTyxFQUFDLENBQUM7QUFBQSxNQUNoRjtBQUFBLElBQ0o7QUFBQTtBQUFBLElBR0Esa0JBQWtCLFNBQVUsU0FBUyxNQUFNO0FBQ3ZDLFVBQUksQ0FBQyxRQUFRO0FBQ1QsaUJBQVMsS0FBSyxJQUFJLGNBQWMsZUFBZTtBQUFBLE1BQ25EO0FBQ0EsWUFBTSxhQUFhLE9BQU8sY0FBYyxvQkFBb0I7QUFFNUQsWUFBTSxPQUFPLEtBQUssWUFBWTtBQUU5QixZQUFNLFNBQVMsT0FBTyxjQUFjLHNCQUFzQjtBQUUxRCxhQUFPLFNBQVM7QUFBQSxRQUNaLEtBQUssS0FBSyxDQUFDLEVBQUUsSUFBSyxPQUFPLGNBQWM7QUFBQSxRQUN2QyxNQUFNLEtBQUssQ0FBQyxFQUFFO0FBQUEsUUFDZCxVQUFVO0FBQUEsTUFDZCxDQUFDO0FBRUQsWUFBTSxRQUFRLEtBQUssQ0FBQyxFQUFFLElBQUksS0FBSyxDQUFDLEVBQUU7QUFDbEMsWUFBTSxTQUFTLEtBQUssQ0FBQyxFQUFFLElBQUksS0FBSyxDQUFDLEVBQUU7QUFFbkMsWUFBTSxJQUFJLEtBQUssQ0FBQyxFQUFFO0FBQ2xCLFlBQU0sSUFBSSxLQUFLLENBQUMsRUFBRTtBQUNsQixhQUFPLE1BQU0sUUFBUSxHQUFHLEtBQUs7QUFDN0IsYUFBTyxNQUFNLFlBQVksYUFBYSxDQUFDLE9BQU8sQ0FBQztBQUMvQyxhQUFPLE1BQU0sU0FBUyxHQUFHLE1BQU07QUFFL0IsaUJBQVcsYUFBYSxLQUFLLEtBQUssWUFBWSxNQUFNLEVBQUMsVUFBVSxNQUFNLFVBQVUsS0FBSSxDQUFDLENBQUM7QUFBQSxJQUN6RjtBQUFBLElBRUEsVUFBVSxTQUFVLFVBQVUsTUFBTSxVQUFVLENBQUMsR0FBRztBQUM5QyxnQkFBVSxXQUFXLEtBQUs7QUFDMUIsZ0JBQVU7QUFBQSxRQUNOLFFBQVE7QUFBQSxRQUNSLFFBQVE7QUFBQSxRQUNSLFFBQVEsRUFBQyxHQUFHLEdBQUcsR0FBRyxFQUFDO0FBQUEsUUFDbkIsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1A7QUFDQSxhQUFPLEdBQUcsS0FBSyxXQUFXLENBQUMsSUFBSSxLQUFLLFlBQVksU0FBUyxPQUFPLENBQUMsR0FBRyxLQUFLO0FBQUEsSUFDN0U7QUFBQSxJQUVBLFlBQVksV0FBWTtBQUNwQixZQUFNLGlCQUFpQixLQUFLO0FBQUEsUUFDeEIsU0FBUyxnQkFBZ0I7QUFBQSxRQUN6QixTQUFTLGdCQUFnQjtBQUFBLFFBQ3pCLFNBQVMsZ0JBQWdCO0FBQUEsTUFDN0I7QUFJQSxVQUFJLE9BQU87QUFDWCxjQUFRLFNBQVMsaUJBQWlCO0FBQ2xDLGNBQVEsT0FBTyxPQUFPLGFBQWEsTUFBTSxpQkFBaUI7QUFDMUQsY0FBUSxPQUFPLE9BQU8sYUFBYTtBQUNuQyxjQUFRO0FBRVIsYUFBTyxLQUFLLEtBQUs7QUFBQSxJQUNyQjtBQUFBLElBRUEsYUFBYSxTQUFVLE1BQU07QUFDekIsYUFBTyxTQUFTLGNBQWMsU0FBUyxRQUFRLE9BQU8sTUFBTSxDQUFDLEtBQ3RELFNBQVMsY0FBYyxRQUFRO0FBQUEsSUFDMUM7QUFBQSxJQUVBLGFBQWEsU0FBVSxVQUFVLE1BQU0sVUFBVSxDQUFDLEdBQUc7QUFDakQsZ0JBQVUsV0FBVyxLQUFLO0FBQzFCLGdCQUFVO0FBQUEsUUFDTixRQUFRO0FBQUEsUUFDUixRQUFRO0FBQUEsUUFDUixRQUFRLEVBQUMsR0FBRyxHQUFHLEdBQUcsRUFBQztBQUFBLFFBQ25CLEdBQUc7QUFBQSxNQUNQO0FBQ0EsWUFBTSxPQUFPLEtBQUssWUFBWSxTQUFTO0FBQUEsUUFDbkMsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1AsQ0FBQztBQUVELFVBQUksT0FBTztBQUNYLGNBQVEsT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVU7QUFDaEUsY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUk7QUFDeEksY0FBUSxRQUFRLEtBQUssQ0FBQyxFQUFFLElBQUksUUFBUSxVQUFVLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSTtBQUNoRSxjQUFRLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVTtBQUN4SSxjQUFRLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksUUFBUSxVQUFVO0FBQ2hFLGNBQVEsT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVUsTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJO0FBQ3hJLGNBQVEsUUFBUSxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUk7QUFDaEUsY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVU7QUFFeEksY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVTtBQUVoRSxhQUFPLEtBQUssS0FBSztBQUFBLElBQ3JCO0FBQUEsSUFFQSxhQUFhLFNBQVUsVUFBVSxNQUFNLFVBQVUsQ0FBQyxHQUFHO0FBRWpELGdCQUFVLFdBQVcsS0FBSztBQUMxQixZQUFNLFNBQVMsUUFBUSxzQkFBc0I7QUFDN0MsZ0JBQVU7QUFBQSxRQUNOLFFBQVE7QUFBQSxRQUNSLFFBQVE7QUFBQSxRQUNSLFFBQVEsRUFBQyxHQUFHLEdBQUcsR0FBRyxFQUFDO0FBQUEsUUFDbkIsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1A7QUFDQSxZQUFNLE9BQU8sUUFBUSxXQUFXLElBQUksT0FBTztBQUMzQyxZQUFNLE1BQU0sUUFBUSxXQUFXLElBQUksUUFBUTtBQUUzQyxVQUFJLFNBQVM7QUFBQSxRQUNUO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFVBQzFDLEdBQUcsTUFBTSxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsUUFDN0M7QUFBQSxRQUNBO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxjQUFjLFFBQVEsU0FBUyxRQUFRLE9BQU87QUFBQSxVQUNoRSxHQUFHLE1BQU0sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFFBQzdDO0FBQUEsUUFDQTtBQUFBLFVBQ0ksR0FBRyxPQUFPLFFBQVEsY0FBYyxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsVUFDaEUsR0FBRyxNQUFNLFFBQVEsZUFBZSxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsUUFDcEU7QUFBQSxRQUNBO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFVBQzFDLEdBQUcsTUFBTSxRQUFRLGVBQWUsUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFFBQ3BFO0FBQUEsTUFDSjtBQUVBLFVBQUksUUFBUSxVQUFVO0FBQ2xCLFlBQUksT0FBTztBQUNYLFlBQUksT0FBTztBQUVYLGlCQUFTLElBQUksR0FBRyxJQUFJLE9BQU8sUUFBUSxLQUFLO0FBQ3BDLGNBQUksT0FBTyxDQUFDLEVBQUUsSUFBSSxNQUFNO0FBQ3BCLG1CQUFPLE9BQU8sQ0FBQyxFQUFFO0FBQUEsVUFDckI7QUFFQSxjQUFJLE9BQU8sQ0FBQyxFQUFFLElBQUksTUFBTTtBQUNwQixtQkFBTyxPQUFPLENBQUMsRUFBRTtBQUFBLFVBQ3JCO0FBQUEsUUFDSjtBQUVBLGlCQUFTLElBQUksR0FBRyxJQUFJLE9BQU8sUUFBUSxLQUFLO0FBQ3BDLGlCQUFPLENBQUMsRUFBRSxLQUFLO0FBQ2YsaUJBQU8sQ0FBQyxFQUFFLEtBQUs7QUFBQSxRQUNuQjtBQUFBLE1BQ0o7QUFFQSxhQUFPO0FBQUEsSUFDWDtBQUFBLEVBQ0o7QUFDSjsiLAogICJuYW1lcyI6IFsia2V5IiwgIm9ic2VydmVyIl0KfQo=
+export { stepComponent as default }
+// # sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vY29tcG9uZW50cy9zdGVwLmpzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJleHBvcnQgZGVmYXVsdCBmdW5jdGlvbiBzdGVwQ29tcG9uZW50KHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGtleSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHNlbGVjdG9yLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgc2hvdWxkSW50ZXJjZXB0Q2xpY2ssXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpbnRlcmNlcHRDbGlja0FjdGlvbixcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgfSkge1xuICAgIHJldHVybiB7XG4gICAgICAgIHRhcmdldDogbnVsbCxcblxuICAgICAgICBzbGVlcDogZnVuY3Rpb24gKG1zKSB7XG4gICAgICAgICAgICByZXR1cm4gbmV3IFByb21pc2UocmVzb2x2ZSA9PiBzZXRUaW1lb3V0KHJlc29sdmUsIG1zKSk7XG4gICAgICAgIH0sXG5cbiAgICAgICAgaW5pdDogYXN5bmMgZnVuY3Rpb24gKCkge1xuICAgICAgICAgICAgdGhpcy50YXJnZXQgPSB0aGlzLmZpbmRFbGVtZW50KGtleSk7XG5cbiAgICAgICAgICAgIGlmICghdGhpcy50YXJnZXQpIHtcbiAgICAgICAgICAgICAgICBjb25zb2xlLmVycm9yKCdUdXRvcmlhbCBzdGVwIHdhcyBub3QgZm91bmQ6Jywga2V5KTtcbiAgICAgICAgICAgICAgICByZXR1cm47XG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIC8vIHdpbmRvdy5ibHVyKCk7XG4gICAgICAgICAgICAvLyBkb2N1bWVudC5kb2N1bWVudEVsZW1lbnQuYmx1cigpO1xuICAgICAgICAgICAgZG9jdW1lbnQuZG9jdW1lbnRFbGVtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJ2lucHV0JylcbiAgICAgICAgICAgICAgICAuZm9yRWFjaCgoZWxlbWVudCkgPT4gZWxlbWVudC5ibHVyKCkpO1xuICAgICAgICAgICAgaWYgKHRoaXMudGFyZ2V0KSB7XG4gICAgICAgICAgICAgICAgdGhpcy50YXJnZXQuZm9jdXMoKTtcbiAgICAgICAgICAgIH1cblxuICAgICAgICAgICAgdGhpcy5jb25maWd1cmUoKTtcblxuICAgICAgICAgICAgY29uc3QgZGlhbG9nID0gdGhpcy4kZWwucXVlcnlTZWxlY3RvcignW2RhdGEtZGlhbG9nXScpO1xuICAgICAgICAgICAgY29uc3QgY2xpcFBhdGggPSB0aGlzLiRlbC5xdWVyeVNlbGVjdG9yKCdbZGF0YS1jbGlwLXBhdGhdJyk7XG5cbiAgICAgICAgICAgIGlmIChzaG91bGRJbnRlcmNlcHRDbGljaykge1xuICAgICAgICAgICAgICAgIHRoaXMudGFyZ2V0LmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKGV2ZW50KSA9PiB7XG4gICAgICAgICAgICAgICAgICAgIGV2ZW50LnByZXZlbnREZWZhdWx0KCk7XG4gICAgICAgICAgICAgICAgICAgIHRoaXMuJHdpcmUuY2FsbChpbnRlcmNlcHRDbGlja0FjdGlvbik7XG5cbiAgICAgICAgICAgICAgICAgICAgdGhpcy50YXJnZXQuYmx1cigpO1xuICAgICAgICAgICAgICAgICAgICBjb25zdCBkZXNjZW5kYW50cyA9IHRoaXMudGFyZ2V0LnF1ZXJ5U2VsZWN0b3JBbGwoXCI6aG92ZXJcIik7XG5cbiAgICAgICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCBkZXNjZW5kYW50cy5sZW5ndGg7IGkrKykge1xuICAgICAgICAgICAgICAgICAgICAgICAgY29uc3QgZGVzY2VuZGFudCA9IGRlc2NlbmRhbnRzW2ldO1xuICAgICAgICAgICAgICAgICAgICAgICAgZGVzY2VuZGFudC5ibHVyKCk7XG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICB9KTtcbiAgICAgICAgICAgIH1cblxuICAgICAgICAgICAgdGhpcy5pbml0aWFsaXplRGlhbG9nKCk7XG5cbiAgICAgICAgICAgIHRoaXMuJG5leHRUaWNrKCgpID0+IHtcbiAgICAgICAgICAgICAgICBjbGlwUGF0aC5zZXRBdHRyaWJ1dGUoJ2QnLCB0aGlzLmNsaXBQYXRoKCkpO1xuICAgICAgICAgICAgICAgIHRoaXMuJGRpc3BhdGNoKCd0dXRvcmlhbDo6cmVuZGVyJyk7XG4gICAgICAgICAgICB9KTtcblxuICAgICAgICAgICAgY2xpcFBhdGguc2V0QXR0cmlidXRlKCdkJywgdGhpcy5jbGlwUGF0aCgpKTtcbiAgICAgICAgfSxcblxuICAgICAgICB0aW1lb3V0czogW10sXG5cbiAgICAgICAgY29uZmlndXJlOiBmdW5jdGlvbiAoKSB7XG4gICAgICAgICAgICBkb2N1bWVudC5hZGRFdmVudExpc3RlbmVyKCdrZXlkb3duJywgZnVuY3Rpb24gKGV2ZW50KSB7XG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBrZXkgY29kZSBvZiB0aGUga2V5IHByZXNzZWRcbiAgICAgICAgICAgICAgICB2YXIga2V5ID0gZXZlbnQua2V5O1xuXG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBzdGF0ZSBvZiB0aGUgbW9kaWZpZXIga2V5c1xuICAgICAgICAgICAgICAgIC8vIHZhciBpc0N0cmxLZXkgPSBldmVudC5jdHJsS2V5IHx8IGV2ZW50Lm1ldGFLZXk7XG4gICAgICAgICAgICAgICAgLy8gdmFyIGlzQWx0S2V5ID0gZXZlbnQuYWx0S2V5O1xuICAgICAgICAgICAgICAgIHZhciBpc1NoaWZ0S2V5ID0gZXZlbnQuc2hpZnRLZXk7XG4gICAgICAgICAgICAgICAgdmFyIGlzQ3RybEtleSA9IGZhbHNlO1xuICAgICAgICAgICAgICAgIHZhciBpc0FsdEtleSA9IGZhbHNlO1xuXG4gICAgICAgICAgICAgICAgLy8gQ2hlY2sgaWYgYW55IGNvbWJpbmF0aW9uIG9mIG1vZGlmaWVyIGtleXMgYW5kIG5vcm1hbCBrZXlzIHdlcmUgcHJlc3NlZFxuICAgICAgICAgICAgICAgIC8vIGlmIChpc0N0cmxLZXkgfHwgaXNBbHRLZXkgfHwgaXNTaGlmdEtleSB8fCBrZXkgPT09ICdUYWInKSB7XG4gICAgICAgICAgICAgICAgLy8gaWYgKGtleSA9PT0gJ1RhYicgfHwgaXNTaGlmdEtleSAmJiBrZXkgPT09ICdUYWInKSB7XG4gICAgICAgICAgICAgICAgaWYgKGtleSA9PT0gJ1RhYicpIHtcbiAgICAgICAgICAgICAgICAgICAgZXZlbnQucHJldmVudERlZmF1bHQoKTsgLy8gUHJldmVudCB0aGUgZGVmYXVsdCBldmVudCBiZWhhdmlvclxuICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgIH0pO1xuXG5cbiAgICAgICAgICAgIGlmICh0aGlzLnRhcmdldCBpbnN0YW5jZW9mIEhUTUxTZWxlY3RFbGVtZW50KSB7XG4gICAgICAgICAgICAgICAgaWYgKHRoaXMudGFyZ2V0Lmhhc0F0dHJpYnV0ZSgnZGF0YS1jaG9pY2UnKSkge1xuICAgICAgICAgICAgICAgICAgICB0aGlzLnRhcmdldCA9IHRoaXMudGFyZ2V0LnBhcmVudEVsZW1lbnQucGFyZW50RWxlbWVudDtcbiAgICAgICAgICAgICAgICAgICAgY29uc3QgZHJvcGRvd24gPSB0aGlzLnRhcmdldC5xdWVyeVNlbGVjdG9yKCcuY2hvaWNlc19fbGlzdC5jaG9pY2VzX19saXN0LS1kcm9wZG93bicpO1xuICAgICAgICAgICAgICAgICAgICBkcm9wZG93bi5zdHlsZS56SW5kZXggPSAxMDA7XG4gICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICBpZiAodGhpcy50YXJnZXQudGFnTmFtZSA9PT0gJ1RSSVgtRURJVE9SJykge1xuICAgICAgICAgICAgICAgIHRoaXMudGltZW91dHNbJ3RyaXgnXSA9IHRoaXMudGFyZ2V0LmNsaWVudEhlaWdodDtcbiAgICAgICAgICAgICAgICB0aGlzLnRhcmdldCA9IHRoaXMudGFyZ2V0LnBhcmVudEVsZW1lbnQ7XG5cbiAgICAgICAgICAgICAgICBjb25zdCBvYnNlcnZlciA9IG5ldyBNdXRhdGlvbk9ic2VydmVyKChtdXRhdGlvbnNMaXN0LCBvYnNlcnZlcikgPT4ge1xuXG4gICAgICAgICAgICAgICAgICAgIG11dGF0aW9uc0xpc3QuZm9yRWFjaCgobXV0YXRpb24pID0+IHtcblxuICAgICAgICAgICAgICAgICAgICAgICAgaWYgKHRoaXMudGltZW91dHNbJ3RyaXgnXSkge1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNsZWFyVGltZW91dCh0aGlzLnRpbWVvdXRzWyd0cml4J10pO1xuICAgICAgICAgICAgICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0cml4J10gPSBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0cml4J10gPSBudWxsO1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMuaW5pdCgpO1xuICAgICAgICAgICAgICAgICAgICAgICAgfSwgNTAwKTtcbiAgICAgICAgICAgICAgICAgICAgfSk7XG4gICAgICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgICAgICBjb25zdCBjb25maWcgPSB7XG4gICAgICAgICAgICAgICAgICAgIGF0dHJpYnV0ZXM6IHRydWUsXG4gICAgICAgICAgICAgICAgICAgIGF0dHJpYnV0ZUZpbHRlcjogWydoZWlnaHQnXSxcbiAgICAgICAgICAgICAgICAgICAgY2hpbGRMaXN0OiB0cnVlLFxuICAgICAgICAgICAgICAgICAgICBzdWJ0cmVlOiB0cnVlLFxuICAgICAgICAgICAgICAgIH07XG5cbiAgICAgICAgICAgICAgICBvYnNlcnZlci5vYnNlcnZlKHRoaXMudGFyZ2V0LCBjb25maWcpO1xuXG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIGlmICh0aGlzLnRhcmdldCBpbnN0YW5jZW9mIEhUTUxUZXh0QXJlYUVsZW1lbnQgfHwgdGhpcy50KSB7XG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBpbml0aWFsIHNpemUgb2YgdGhlIHRleHRhcmVhXG4gICAgICAgICAgICAgICAgbGV0IGluaXRpYWxXaWR0aCA9IHRoaXMudGFyZ2V0Lm9mZnNldFdpZHRoO1xuICAgICAgICAgICAgICAgIGxldCBpbml0aWFsSGVpZ2h0ID0gdGhpcy50YXJnZXQub2Zmc2V0SGVpZ2h0O1xuXG4gICAgICAgICAgICAgICAgLy8gQ3JlYXRlIGEgTXV0YXRpb25PYnNlcnZlciB0byBtb25pdG9yIHNpemUgY2hhbmdlc1xuICAgICAgICAgICAgICAgIGNvbnN0IG9ic2VydmVyID0gbmV3IE11dGF0aW9uT2JzZXJ2ZXIoKCkgPT4ge1xuICAgICAgICAgICAgICAgICAgICBpZiAodGhpcy50YXJnZXQub2Zmc2V0V2lkdGggIT09IGluaXRpYWxXaWR0aCB8fCB0aGlzLnRhcmdldC5vZmZzZXRIZWlnaHQgIT09IGluaXRpYWxIZWlnaHQpIHtcbiAgICAgICAgICAgICAgICAgICAgICAgIGluaXRpYWxXaWR0aCA9IHRoaXMudGFyZ2V0Lm9mZnNldFdpZHRoO1xuICAgICAgICAgICAgICAgICAgICAgICAgaW5pdGlhbEhlaWdodCA9IHRoaXMudGFyZ2V0Lm9mZnNldEhlaWdodDtcblxuICAgICAgICAgICAgICAgICAgICAgICAgaWYgKHRoaXMudGltZW91dHNbJ3RleHRhcmVhJ10pIHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICBjbGVhclRpbWVvdXQodGhpcy50aW1lb3V0c1sndGV4dGFyZWEnXSk7XG4gICAgICAgICAgICAgICAgICAgICAgICB9XG5cbiAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMudGltZW91dHNbJ3RleHRhcmVhJ10gPSBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0ZXh0YXJlYSddID0gbnVsbDtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLmluaXQoKTtcbiAgICAgICAgICAgICAgICAgICAgICAgIH0sIDEwMCk7XG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICB9KTtcblxuICAgICAgICAgICAgICAgIC8vIFN0YXJ0IG9ic2VydmluZyBjaGFuZ2VzIGluIHRoZSB0ZXh0YXJlYSBlbGVtZW50XG4gICAgICAgICAgICAgICAgb2JzZXJ2ZXIub2JzZXJ2ZSh0aGlzLnRhcmdldCwge2F0dHJpYnV0ZXM6IHRydWUsIGF0dHJpYnV0ZUZpbHRlcjogWydzdHlsZSddfSk7XG4gICAgICAgICAgICB9XG4gICAgICAgIH0sXG4gICAgICAgIC8vIFlvdSBjYW4gZGVmaW5lIGFueSBvdGhlciBBbHBpbmUuanMgZnVuY3Rpb25zIGhlcmUuXG5cbiAgICAgICAgaW5pdGlhbGl6ZURpYWxvZzogZnVuY3Rpb24gKGRpYWxvZyA9IG51bGwpIHtcbiAgICAgICAgICAgIGlmICghZGlhbG9nKSB7XG4gICAgICAgICAgICAgICAgZGlhbG9nID0gdGhpcy4kZWwucXVlcnlTZWxlY3RvcignW2RhdGEtZGlhbG9nXScpO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgZGlhbG9nUGF0aCA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCdbZGF0YS1kaWFsb2ctcGF0aF0nKTtcblxuICAgICAgICAgICAgY29uc3QgcmVjdCA9IHRoaXMuZWxlbWVudFJlY3QoKTtcbiAgICAgICAgICAgIC8vIGNvbnN0IGhlYWRlciA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCdbZGF0YS1kaWFsb2ctaGVhZGVyXScpO1xuICAgICAgICAgICAgY29uc3Qgc3Ryb2tlID0gZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJ1tkYXRhLWRpYWxvZy1zdHJva2VdJyk7XG5cbiAgICAgICAgICAgIHdpbmRvdy5zY3JvbGxUbyh7XG4gICAgICAgICAgICAgICAgdG9wOiByZWN0WzBdLnkgLSAod2luZG93LmlubmVySGVpZ2h0IC8gMyksXG4gICAgICAgICAgICAgICAgbGVmdDogcmVjdFswXS54LFxuICAgICAgICAgICAgICAgIGJlaGF2aW9yOiAnc21vb3RoJ1xuICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgIGNvbnN0IHdpZHRoID0gcmVjdFsxXS54IC0gcmVjdFswXS54O1xuICAgICAgICAgICAgY29uc3QgaGVpZ2h0ID0gcmVjdFsyXS55IC0gcmVjdFswXS55O1xuXG4gICAgICAgICAgICBjb25zdCB4ID0gcmVjdFswXS54O1xuICAgICAgICAgICAgY29uc3QgeSA9IHJlY3RbMF0ueTtcbiAgICAgICAgICAgIGRpYWxvZy5zdHlsZS53aWR0aCA9IGAke3dpZHRofXB4YDtcbiAgICAgICAgICAgIGRpYWxvZy5zdHlsZS50cmFuc2Zvcm0gPSBgdHJhbnNsYXRlKCR7eH1weCwgJHt5fXB4KWA7XG4gICAgICAgICAgICBzdHJva2Uuc3R5bGUuaGVpZ2h0ID0gYCR7aGVpZ2h0fXB4YDtcblxuICAgICAgICAgICAgZGlhbG9nUGF0aC5zZXRBdHRyaWJ1dGUoJ2QnLCB0aGlzLmVsZW1lbnRQYXRoKG51bGwsIHtyZWxhdGl2ZTogdHJ1ZSwgcG9zaXRpdmU6IHRydWV9KSlcbiAgICAgICAgfSxcblxuICAgICAgICBjbGlwUGF0aDogZnVuY3Rpb24gKGVsZW1lbnQgPSBudWxsLCBvcHRpb25zID0ge30pIHtcbiAgICAgICAgICAgIGVsZW1lbnQgPSBlbGVtZW50IHx8IHRoaXMudGFyZ2V0O1xuICAgICAgICAgICAgb3B0aW9ucyA9IHtcbiAgICAgICAgICAgICAgICByYWRpdXM6IDI0LFxuICAgICAgICAgICAgICAgIG1hcmdpbjogMTAsXG4gICAgICAgICAgICAgICAgb2Zmc2V0OiB7eDogMCwgeTogMH0sXG4gICAgICAgICAgICAgICAgcmVsYXRpdmU6IGZhbHNlLFxuICAgICAgICAgICAgICAgIC4uLm9wdGlvbnNcbiAgICAgICAgICAgIH1cbiAgICAgICAgICAgIHJldHVybiBgJHt0aGlzLndpbmRvd1BhdGgoKX0gJHt0aGlzLmVsZW1lbnRQYXRoKGVsZW1lbnQsIG9wdGlvbnMpfWAudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIHdpbmRvd1BhdGg6IGZ1bmN0aW9uICgpIHtcbiAgICAgICAgICAgIGNvbnN0IGRvY3VtZW50SGVpZ2h0ID0gTWF0aC5tYXgoXG4gICAgICAgICAgICAgICAgZG9jdW1lbnQuZG9jdW1lbnRFbGVtZW50LmNsaWVudEhlaWdodCxcbiAgICAgICAgICAgICAgICBkb2N1bWVudC5kb2N1bWVudEVsZW1lbnQuc2Nyb2xsSGVpZ2h0LFxuICAgICAgICAgICAgICAgIGRvY3VtZW50LmRvY3VtZW50RWxlbWVudC5vZmZzZXRIZWlnaHQsXG4gICAgICAgICAgICApO1xuXG4gICAgICAgICAgICAvLyBUT0RPOiBhZGQgb3B0aW9uIHRvIHNlbGVjdCBjbG9ja3dpc2UgL2NvdW50ZXIgY2xvY2t3aXNlXG4gICAgICAgICAgICAvL00gMCA4IEMgMCAwIDAgMCA4IDAgTCAzOCAwIEMgNDYgMCA0NiAwIDQ2IDggQyA0NiAxNiA0NiAxNiAzOCAxNiBMIDggMTYgQyAwIDE2IDAgMTYgMCA4XG4gICAgICAgICAgICBsZXQgcGF0aCA9ICdNIDAgMCAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAwICcgKyBkb2N1bWVudEhlaWdodCArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0wgJyArIHdpbmRvdy5pbm5lcldpZHRoICsgJyAnICsgZG9jdW1lbnRIZWlnaHQgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdMICcgKyB3aW5kb3cuaW5uZXJXaWR0aCArICcgMCAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAwIDAgJztcblxuICAgICAgICAgICAgcmV0dXJuIHBhdGgudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIGZpbmRFbGVtZW50OiBmdW5jdGlvbiAobmFtZSkge1xuICAgICAgICAgICAgcmV0dXJuIGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3Ioc2VsZWN0b3IucmVwbGFjZSgvXFwuL2csICdcXFxcJCYnKSlcbiAgICAgICAgICAgICAgICA/PyBkb2N1bWVudC5xdWVyeVNlbGVjdG9yKHNlbGVjdG9yKTtcbiAgICAgICAgfSxcblxuICAgICAgICBlbGVtZW50UGF0aDogZnVuY3Rpb24gKGVsZW1lbnQgPSBudWxsLCBvcHRpb25zID0ge30pIHtcbiAgICAgICAgICAgIGVsZW1lbnQgPSBlbGVtZW50IHx8IHRoaXMudGFyZ2V0O1xuICAgICAgICAgICAgb3B0aW9ucyA9IHtcbiAgICAgICAgICAgICAgICByYWRpdXM6IDI0LFxuICAgICAgICAgICAgICAgIG1hcmdpbjogMTAsXG4gICAgICAgICAgICAgICAgb2Zmc2V0OiB7eDogMCwgeTogMH0sXG4gICAgICAgICAgICAgICAgLi4ub3B0aW9uc1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgcmVjdCA9IHRoaXMuZWxlbWVudFJlY3QoZWxlbWVudCwge1xuICAgICAgICAgICAgICAgIHJlbGF0aXZlOiBmYWxzZSxcbiAgICAgICAgICAgICAgICAuLi5vcHRpb25zLFxuICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgIGxldCBwYXRoID0gJyc7XG4gICAgICAgICAgICBwYXRoICs9ICdNICcgKyByZWN0WzBdLnggKyAnICcgKyAocmVjdFswXS55ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnQyAnICsgcmVjdFswXS54ICsgJyAnICsgcmVjdFswXS55ICsgJyAnICsgcmVjdFswXS54ICsgJyAnICsgcmVjdFswXS55ICsgJyAnICsgKHJlY3RbMF0ueCArIG9wdGlvbnMucmFkaXVzKSArICcgJyArIHJlY3RbMF0ueSArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0wgJyArIChyZWN0WzFdLnggLSBvcHRpb25zLnJhZGl1cykgKyAnICcgKyByZWN0WzFdLnkgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdDICcgKyByZWN0WzFdLnggKyAnICcgKyByZWN0WzFdLnkgKyAnICcgKyByZWN0WzFdLnggKyAnICcgKyByZWN0WzFdLnkgKyAnICcgKyByZWN0WzFdLnggKyAnICcgKyAocmVjdFsxXS55ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAnICsgcmVjdFsyXS54ICsgJyAnICsgKHJlY3RbMl0ueSAtIG9wdGlvbnMucmFkaXVzKSArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0MgJyArIHJlY3RbMl0ueCArICcgJyArIHJlY3RbMl0ueSArICcgJyArIHJlY3RbMl0ueCArICcgJyArIHJlY3RbMl0ueSArICcgJyArIChyZWN0WzJdLnggLSBvcHRpb25zLnJhZGl1cykgKyAnICcgKyByZWN0WzJdLnkgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdMICcgKyAocmVjdFszXS54ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnICsgcmVjdFszXS55ICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnQyAnICsgcmVjdFszXS54ICsgJyAnICsgcmVjdFszXS55ICsgJyAnICsgcmVjdFszXS54ICsgJyAnICsgcmVjdFszXS55ICsgJyAnICsgcmVjdFszXS54ICsgJyAnICsgKHJlY3RbM10ueSAtIG9wdGlvbnMucmFkaXVzKSArICcgJztcbiAgICAgICAgICAgIC8vIHBhdGggKz0gJ1onO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAnICsgcmVjdFswXS54ICsgJyAnICsgKHJlY3RbMF0ueSArIG9wdGlvbnMucmFkaXVzKSArICcgJztcblxuICAgICAgICAgICAgcmV0dXJuIHBhdGgudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIGVsZW1lbnRSZWN0OiBmdW5jdGlvbiAoZWxlbWVudCA9IG51bGwsIG9wdGlvbnMgPSB7fSkge1xuXG4gICAgICAgICAgICBlbGVtZW50ID0gZWxlbWVudCB8fCB0aGlzLnRhcmdldDtcbiAgICAgICAgICAgIGNvbnN0IGJvdW5kcyA9IGVsZW1lbnQuZ2V0Qm91bmRpbmdDbGllbnRSZWN0KCk7XG4gICAgICAgICAgICBvcHRpb25zID0ge1xuICAgICAgICAgICAgICAgIHJhZGl1czogMjQsXG4gICAgICAgICAgICAgICAgbWFyZ2luOiAxMCxcbiAgICAgICAgICAgICAgICBvZmZzZXQ6IHt4OiAwLCB5OiAwfSxcbiAgICAgICAgICAgICAgICByZWxhdGl2ZTogZmFsc2UsXG4gICAgICAgICAgICAgICAgLi4ub3B0aW9uc1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgbGVmdCA9IG9wdGlvbnMucmVsYXRpdmUgPyAwIDogYm91bmRzLmxlZnQ7XG4gICAgICAgICAgICBjb25zdCB0b3AgPSBvcHRpb25zLnJlbGF0aXZlID8gMCA6IGVsZW1lbnQub2Zmc2V0VG9wO1xuXG4gICAgICAgICAgICBsZXQgcmVzdWx0ID0gW1xuICAgICAgICAgICAgICAgIHtcbiAgICAgICAgICAgICAgICAgICAgeDogbGVmdCAtIG9wdGlvbnMubWFyZ2luICsgb3B0aW9ucy5vZmZzZXQueCxcbiAgICAgICAgICAgICAgICAgICAgeTogdG9wIC0gb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfSxcbiAgICAgICAgICAgICAgICB7XG4gICAgICAgICAgICAgICAgICAgIHg6IGxlZnQgKyBlbGVtZW50LmNsaWVudFdpZHRoICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC54LFxuICAgICAgICAgICAgICAgICAgICB5OiB0b3AgLSBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LnlcbiAgICAgICAgICAgICAgICB9LFxuICAgICAgICAgICAgICAgIHtcbiAgICAgICAgICAgICAgICAgICAgeDogbGVmdCArIGVsZW1lbnQuY2xpZW50V2lkdGggKyBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LngsXG4gICAgICAgICAgICAgICAgICAgIHk6IHRvcCArIGVsZW1lbnQuY2xpZW50SGVpZ2h0ICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfSxcbiAgICAgICAgICAgICAgICB7XG4gICAgICAgICAgICAgICAgICAgIHg6IGxlZnQgLSBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LngsXG4gICAgICAgICAgICAgICAgICAgIHk6IHRvcCArIGVsZW1lbnQuY2xpZW50SGVpZ2h0ICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgXTtcblxuICAgICAgICAgICAgaWYgKG9wdGlvbnMucG9zaXRpdmUpIHtcbiAgICAgICAgICAgICAgICBsZXQgbWluWCA9IDA7XG4gICAgICAgICAgICAgICAgbGV0IG1pblkgPSAwO1xuXG4gICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCByZXN1bHQubGVuZ3RoOyBpKyspIHtcbiAgICAgICAgICAgICAgICAgICAgaWYgKHJlc3VsdFtpXS54IDwgbWluWCkge1xuICAgICAgICAgICAgICAgICAgICAgICAgbWluWCA9IHJlc3VsdFtpXS54O1xuICAgICAgICAgICAgICAgICAgICB9XG5cbiAgICAgICAgICAgICAgICAgICAgaWYgKHJlc3VsdFtpXS55IDwgbWluWSkge1xuICAgICAgICAgICAgICAgICAgICAgICAgbWluWSA9IHJlc3VsdFtpXS55O1xuICAgICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCByZXN1bHQubGVuZ3RoOyBpKyspIHtcbiAgICAgICAgICAgICAgICAgICAgcmVzdWx0W2ldLnggLT0gbWluWDtcbiAgICAgICAgICAgICAgICAgICAgcmVzdWx0W2ldLnkgLT0gbWluWTtcbiAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIHJldHVybiByZXN1bHQ7XG4gICAgICAgIH1cbiAgICB9XG59Il0sCiAgIm1hcHBpbmdzIjogIjtBQUFlLFNBQVIsY0FBK0I7QUFBQSxFQUNJO0FBQUEsRUFDQTtBQUFBLEVBQ0E7QUFBQSxFQUNBO0FBQ0osR0FBRztBQUNyQyxTQUFPO0FBQUEsSUFDSCxRQUFRO0FBQUEsSUFFUixPQUFPLFNBQVUsSUFBSTtBQUNqQixhQUFPLElBQUksUUFBUSxhQUFXLFdBQVcsU0FBUyxFQUFFLENBQUM7QUFBQSxJQUN6RDtBQUFBLElBRUEsTUFBTSxpQkFBa0I7QUFDcEIsV0FBSyxTQUFTLEtBQUssWUFBWSxHQUFHO0FBRWxDLFVBQUksQ0FBQyxLQUFLLFFBQVE7QUFDZCxnQkFBUSxNQUFNLGdDQUFnQyxHQUFHO0FBQ2pEO0FBQUEsTUFDSjtBQUlBLGVBQVMsZ0JBQWdCLGlCQUFpQixPQUFPLEVBQzVDLFFBQVEsQ0FBQyxZQUFZLFFBQVEsS0FBSyxDQUFDO0FBQ3hDLFVBQUksS0FBSyxRQUFRO0FBQ2IsYUFBSyxPQUFPLE1BQU07QUFBQSxNQUN0QjtBQUVBLFdBQUssVUFBVTtBQUVmLFlBQU0sU0FBUyxLQUFLLElBQUksY0FBYyxlQUFlO0FBQ3JELFlBQU0sV0FBVyxLQUFLLElBQUksY0FBYyxrQkFBa0I7QUFFMUQsVUFBSSxzQkFBc0I7QUFDdEIsYUFBSyxPQUFPLGlCQUFpQixTQUFTLENBQUMsVUFBVTtBQUM3QyxnQkFBTSxlQUFlO0FBQ3JCLGVBQUssTUFBTSxLQUFLLG9CQUFvQjtBQUVwQyxlQUFLLE9BQU8sS0FBSztBQUNqQixnQkFBTSxjQUFjLEtBQUssT0FBTyxpQkFBaUIsUUFBUTtBQUV6RCxtQkFBUyxJQUFJLEdBQUcsSUFBSSxZQUFZLFFBQVEsS0FBSztBQUN6QyxrQkFBTSxhQUFhLFlBQVksQ0FBQztBQUNoQyx1QkFBVyxLQUFLO0FBQUEsVUFDcEI7QUFBQSxRQUNKLENBQUM7QUFBQSxNQUNMO0FBRUEsV0FBSyxpQkFBaUI7QUFFdEIsV0FBSyxVQUFVLE1BQU07QUFDakIsaUJBQVMsYUFBYSxLQUFLLEtBQUssU0FBUyxDQUFDO0FBQzFDLGFBQUssVUFBVSxrQkFBa0I7QUFBQSxNQUNyQyxDQUFDO0FBRUQsZUFBUyxhQUFhLEtBQUssS0FBSyxTQUFTLENBQUM7QUFBQSxJQUM5QztBQUFBLElBRUEsVUFBVSxDQUFDO0FBQUEsSUFFWCxXQUFXLFdBQVk7QUFDbkIsZUFBUyxpQkFBaUIsV0FBVyxTQUFVLE9BQU87QUFFbEQsWUFBSUEsT0FBTSxNQUFNO0FBS2hCLFlBQUksYUFBYSxNQUFNO0FBQ3ZCLFlBQUksWUFBWTtBQUNoQixZQUFJLFdBQVc7QUFLZixZQUFJQSxTQUFRLE9BQU87QUFDZixnQkFBTSxlQUFlO0FBQUEsUUFDekI7QUFBQSxNQUNKLENBQUM7QUFHRCxVQUFJLEtBQUssa0JBQWtCLG1CQUFtQjtBQUMxQyxZQUFJLEtBQUssT0FBTyxhQUFhLGFBQWEsR0FBRztBQUN6QyxlQUFLLFNBQVMsS0FBSyxPQUFPLGNBQWM7QUFDeEMsZ0JBQU0sV0FBVyxLQUFLLE9BQU8sY0FBYyx3Q0FBd0M7QUFDbkYsbUJBQVMsTUFBTSxTQUFTO0FBQUEsUUFDNUI7QUFBQSxNQUNKO0FBRUEsVUFBSSxLQUFLLE9BQU8sWUFBWSxlQUFlO0FBQ3ZDLGFBQUssU0FBUyxNQUFNLElBQUksS0FBSyxPQUFPO0FBQ3BDLGFBQUssU0FBUyxLQUFLLE9BQU87QUFFMUIsY0FBTSxXQUFXLElBQUksaUJBQWlCLENBQUMsZUFBZUMsY0FBYTtBQUUvRCx3QkFBYyxRQUFRLENBQUMsYUFBYTtBQUVoQyxnQkFBSSxLQUFLLFNBQVMsTUFBTSxHQUFHO0FBQ3ZCLDJCQUFhLEtBQUssU0FBUyxNQUFNLENBQUM7QUFBQSxZQUN0QztBQUVBLGlCQUFLLFNBQVMsTUFBTSxJQUFJLFdBQVcsTUFBTTtBQUNyQyxtQkFBSyxTQUFTLE1BQU0sSUFBSTtBQUN4QixtQkFBSyxLQUFLO0FBQUEsWUFDZCxHQUFHLEdBQUc7QUFBQSxVQUNWLENBQUM7QUFBQSxRQUNMLENBQUM7QUFFRCxjQUFNLFNBQVM7QUFBQSxVQUNYLFlBQVk7QUFBQSxVQUNaLGlCQUFpQixDQUFDLFFBQVE7QUFBQSxVQUMxQixXQUFXO0FBQUEsVUFDWCxTQUFTO0FBQUEsUUFDYjtBQUVBLGlCQUFTLFFBQVEsS0FBSyxRQUFRLE1BQU07QUFBQSxNQUV4QztBQUVBLFVBQUksS0FBSyxrQkFBa0IsdUJBQXVCLEtBQUssR0FBRztBQUV0RCxZQUFJLGVBQWUsS0FBSyxPQUFPO0FBQy9CLFlBQUksZ0JBQWdCLEtBQUssT0FBTztBQUdoQyxjQUFNLFdBQVcsSUFBSSxpQkFBaUIsTUFBTTtBQUN4QyxjQUFJLEtBQUssT0FBTyxnQkFBZ0IsZ0JBQWdCLEtBQUssT0FBTyxpQkFBaUIsZUFBZTtBQUN4RiwyQkFBZSxLQUFLLE9BQU87QUFDM0IsNEJBQWdCLEtBQUssT0FBTztBQUU1QixnQkFBSSxLQUFLLFNBQVMsVUFBVSxHQUFHO0FBQzNCLDJCQUFhLEtBQUssU0FBUyxVQUFVLENBQUM7QUFBQSxZQUMxQztBQUVBLGlCQUFLLFNBQVMsVUFBVSxJQUFJLFdBQVcsTUFBTTtBQUN6QyxtQkFBSyxTQUFTLFVBQVUsSUFBSTtBQUM1QixtQkFBSyxLQUFLO0FBQUEsWUFDZCxHQUFHLEdBQUc7QUFBQSxVQUNWO0FBQUEsUUFDSixDQUFDO0FBR0QsaUJBQVMsUUFBUSxLQUFLLFFBQVEsRUFBQyxZQUFZLE1BQU0saUJBQWlCLENBQUMsT0FBTyxFQUFDLENBQUM7QUFBQSxNQUNoRjtBQUFBLElBQ0o7QUFBQTtBQUFBLElBR0Esa0JBQWtCLFNBQVUsU0FBUyxNQUFNO0FBQ3ZDLFVBQUksQ0FBQyxRQUFRO0FBQ1QsaUJBQVMsS0FBSyxJQUFJLGNBQWMsZUFBZTtBQUFBLE1BQ25EO0FBQ0EsWUFBTSxhQUFhLE9BQU8sY0FBYyxvQkFBb0I7QUFFNUQsWUFBTSxPQUFPLEtBQUssWUFBWTtBQUU5QixZQUFNLFNBQVMsT0FBTyxjQUFjLHNCQUFzQjtBQUUxRCxhQUFPLFNBQVM7QUFBQSxRQUNaLEtBQUssS0FBSyxDQUFDLEVBQUUsSUFBSyxPQUFPLGNBQWM7QUFBQSxRQUN2QyxNQUFNLEtBQUssQ0FBQyxFQUFFO0FBQUEsUUFDZCxVQUFVO0FBQUEsTUFDZCxDQUFDO0FBRUQsWUFBTSxRQUFRLEtBQUssQ0FBQyxFQUFFLElBQUksS0FBSyxDQUFDLEVBQUU7QUFDbEMsWUFBTSxTQUFTLEtBQUssQ0FBQyxFQUFFLElBQUksS0FBSyxDQUFDLEVBQUU7QUFFbkMsWUFBTSxJQUFJLEtBQUssQ0FBQyxFQUFFO0FBQ2xCLFlBQU0sSUFBSSxLQUFLLENBQUMsRUFBRTtBQUNsQixhQUFPLE1BQU0sUUFBUSxHQUFHLEtBQUs7QUFDN0IsYUFBTyxNQUFNLFlBQVksYUFBYSxDQUFDLE9BQU8sQ0FBQztBQUMvQyxhQUFPLE1BQU0sU0FBUyxHQUFHLE1BQU07QUFFL0IsaUJBQVcsYUFBYSxLQUFLLEtBQUssWUFBWSxNQUFNLEVBQUMsVUFBVSxNQUFNLFVBQVUsS0FBSSxDQUFDLENBQUM7QUFBQSxJQUN6RjtBQUFBLElBRUEsVUFBVSxTQUFVLFVBQVUsTUFBTSxVQUFVLENBQUMsR0FBRztBQUM5QyxnQkFBVSxXQUFXLEtBQUs7QUFDMUIsZ0JBQVU7QUFBQSxRQUNOLFFBQVE7QUFBQSxRQUNSLFFBQVE7QUFBQSxRQUNSLFFBQVEsRUFBQyxHQUFHLEdBQUcsR0FBRyxFQUFDO0FBQUEsUUFDbkIsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1A7QUFDQSxhQUFPLEdBQUcsS0FBSyxXQUFXLENBQUMsSUFBSSxLQUFLLFlBQVksU0FBUyxPQUFPLENBQUMsR0FBRyxLQUFLO0FBQUEsSUFDN0U7QUFBQSxJQUVBLFlBQVksV0FBWTtBQUNwQixZQUFNLGlCQUFpQixLQUFLO0FBQUEsUUFDeEIsU0FBUyxnQkFBZ0I7QUFBQSxRQUN6QixTQUFTLGdCQUFnQjtBQUFBLFFBQ3pCLFNBQVMsZ0JBQWdCO0FBQUEsTUFDN0I7QUFJQSxVQUFJLE9BQU87QUFDWCxjQUFRLFNBQVMsaUJBQWlCO0FBQ2xDLGNBQVEsT0FBTyxPQUFPLGFBQWEsTUFBTSxpQkFBaUI7QUFDMUQsY0FBUSxPQUFPLE9BQU8sYUFBYTtBQUNuQyxjQUFRO0FBRVIsYUFBTyxLQUFLLEtBQUs7QUFBQSxJQUNyQjtBQUFBLElBRUEsYUFBYSxTQUFVLE1BQU07QUFDekIsYUFBTyxTQUFTLGNBQWMsU0FBUyxRQUFRLE9BQU8sTUFBTSxDQUFDLEtBQ3RELFNBQVMsY0FBYyxRQUFRO0FBQUEsSUFDMUM7QUFBQSxJQUVBLGFBQWEsU0FBVSxVQUFVLE1BQU0sVUFBVSxDQUFDLEdBQUc7QUFDakQsZ0JBQVUsV0FBVyxLQUFLO0FBQzFCLGdCQUFVO0FBQUEsUUFDTixRQUFRO0FBQUEsUUFDUixRQUFRO0FBQUEsUUFDUixRQUFRLEVBQUMsR0FBRyxHQUFHLEdBQUcsRUFBQztBQUFBLFFBQ25CLEdBQUc7QUFBQSxNQUNQO0FBQ0EsWUFBTSxPQUFPLEtBQUssWUFBWSxTQUFTO0FBQUEsUUFDbkMsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1AsQ0FBQztBQUVELFVBQUksT0FBTztBQUNYLGNBQVEsT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVU7QUFDaEUsY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUk7QUFDeEksY0FBUSxRQUFRLEtBQUssQ0FBQyxFQUFFLElBQUksUUFBUSxVQUFVLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSTtBQUNoRSxjQUFRLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVTtBQUN4SSxjQUFRLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksUUFBUSxVQUFVO0FBQ2hFLGNBQVEsT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVUsTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJO0FBQ3hJLGNBQVEsUUFBUSxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUk7QUFDaEUsY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVU7QUFFeEksY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVTtBQUVoRSxhQUFPLEtBQUssS0FBSztBQUFBLElBQ3JCO0FBQUEsSUFFQSxhQUFhLFNBQVUsVUFBVSxNQUFNLFVBQVUsQ0FBQyxHQUFHO0FBRWpELGdCQUFVLFdBQVcsS0FBSztBQUMxQixZQUFNLFNBQVMsUUFBUSxzQkFBc0I7QUFDN0MsZ0JBQVU7QUFBQSxRQUNOLFFBQVE7QUFBQSxRQUNSLFFBQVE7QUFBQSxRQUNSLFFBQVEsRUFBQyxHQUFHLEdBQUcsR0FBRyxFQUFDO0FBQUEsUUFDbkIsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1A7QUFDQSxZQUFNLE9BQU8sUUFBUSxXQUFXLElBQUksT0FBTztBQUMzQyxZQUFNLE1BQU0sUUFBUSxXQUFXLElBQUksUUFBUTtBQUUzQyxVQUFJLFNBQVM7QUFBQSxRQUNUO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFVBQzFDLEdBQUcsTUFBTSxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsUUFDN0M7QUFBQSxRQUNBO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxjQUFjLFFBQVEsU0FBUyxRQUFRLE9BQU87QUFBQSxVQUNoRSxHQUFHLE1BQU0sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFFBQzdDO0FBQUEsUUFDQTtBQUFBLFVBQ0ksR0FBRyxPQUFPLFFBQVEsY0FBYyxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsVUFDaEUsR0FBRyxNQUFNLFFBQVEsZUFBZSxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsUUFDcEU7QUFBQSxRQUNBO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFVBQzFDLEdBQUcsTUFBTSxRQUFRLGVBQWUsUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFFBQ3BFO0FBQUEsTUFDSjtBQUVBLFVBQUksUUFBUSxVQUFVO0FBQ2xCLFlBQUksT0FBTztBQUNYLFlBQUksT0FBTztBQUVYLGlCQUFTLElBQUksR0FBRyxJQUFJLE9BQU8sUUFBUSxLQUFLO0FBQ3BDLGNBQUksT0FBTyxDQUFDLEVBQUUsSUFBSSxNQUFNO0FBQ3BCLG1CQUFPLE9BQU8sQ0FBQyxFQUFFO0FBQUEsVUFDckI7QUFFQSxjQUFJLE9BQU8sQ0FBQyxFQUFFLElBQUksTUFBTTtBQUNwQixtQkFBTyxPQUFPLENBQUMsRUFBRTtBQUFBLFVBQ3JCO0FBQUEsUUFDSjtBQUVBLGlCQUFTLElBQUksR0FBRyxJQUFJLE9BQU8sUUFBUSxLQUFLO0FBQ3BDLGlCQUFPLENBQUMsRUFBRSxLQUFLO0FBQ2YsaUJBQU8sQ0FBQyxFQUFFLEtBQUs7QUFBQSxRQUNuQjtBQUFBLE1BQ0o7QUFFQSxhQUFPO0FBQUEsSUFDWDtBQUFBLEVBQ0o7QUFDSjsiLAogICJuYW1lcyI6IFsia2V5IiwgIm9ic2VydmVyIl0KfQo=

--- a/public/js/guava/tutorials/components/step.js
+++ b/public/js/guava/tutorials/components/step.js
@@ -1,9 +1,9 @@
 // resources/js/components/step.js
 function stepComponent({
-    key,
-    selector,
-    shouldInterceptClick,
-    interceptClickAction,
+                           key,
+                           selector,
+                           shouldInterceptClick,
+                           interceptClickAction
 }) {
     return {
         target: null,
@@ -16,9 +16,7 @@ function stepComponent({
                 console.error("Tutorial step was not found:", key);
                 return;
             }
-            document.documentElement
-                .querySelectorAll("input")
-                .forEach((element) => element.blur());
+            document.documentElement.querySelectorAll("input").forEach((element) => element.blur());
             if (this.target) {
                 this.target.focus();
             }
@@ -47,10 +45,10 @@ function stepComponent({
         timeouts: [],
         configure: function () {
             document.addEventListener("keydown", function (event) {
-                const key2 = event.key;
-                const isShiftKey = event.shiftKey;
-                const isCtrlKey = false;
-                const isAltKey = false;
+                var key2 = event.key;
+                var isShiftKey = event.shiftKey;
+                var isCtrlKey = false;
+                var isAltKey = false;
                 if (key2 === "Tab") {
                     event.preventDefault();
                 }
@@ -58,33 +56,29 @@ function stepComponent({
             if (this.target instanceof HTMLSelectElement) {
                 if (this.target.hasAttribute("data-choice")) {
                     this.target = this.target.parentElement.parentElement;
-                    const dropdown = this.target.querySelector(
-                        ".choices__list.choices__list--dropdown",
-                    );
+                    const dropdown = this.target.querySelector(".choices__list.choices__list--dropdown");
                     dropdown.style.zIndex = 100;
                 }
             }
             if (this.target.tagName === "TRIX-EDITOR") {
-                this.timeouts.trix = this.target.clientHeight;
+                this.timeouts["trix"] = this.target.clientHeight;
                 this.target = this.target.parentElement;
-                const observer = new MutationObserver(
-                    (mutationsList, observer2) => {
-                        mutationsList.forEach((mutation) => {
-                            if (this.timeouts.trix) {
-                                clearTimeout(this.timeouts.trix);
-                            }
-                            this.timeouts.trix = setTimeout(() => {
-                                this.timeouts.trix = null;
-                                this.init();
-                            }, 500);
-                        });
-                    },
-                );
+                const observer = new MutationObserver((mutationsList, observer2) => {
+                    mutationsList.forEach((mutation) => {
+                        if (this.timeouts["trix"]) {
+                            clearTimeout(this.timeouts["trix"]);
+                        }
+                        this.timeouts["trix"] = setTimeout(() => {
+                            this.timeouts["trix"] = null;
+                            this.init();
+                        }, 500);
+                    });
+                });
                 const config = {
                     attributes: true,
                     attributeFilter: ["height"],
                     childList: true,
-                    subtree: true,
+                    subtree: true
                 };
                 observer.observe(this.target, config);
             }
@@ -92,25 +86,19 @@ function stepComponent({
                 let initialWidth = this.target.offsetWidth;
                 let initialHeight = this.target.offsetHeight;
                 const observer = new MutationObserver(() => {
-                    if (
-                        this.target.offsetWidth !== initialWidth ||
-                        this.target.offsetHeight !== initialHeight
-                    ) {
+                    if (this.target.offsetWidth !== initialWidth || this.target.offsetHeight !== initialHeight) {
                         initialWidth = this.target.offsetWidth;
                         initialHeight = this.target.offsetHeight;
-                        if (this.timeouts.textarea) {
-                            clearTimeout(this.timeouts.textarea);
+                        if (this.timeouts["textarea"]) {
+                            clearTimeout(this.timeouts["textarea"]);
                         }
-                        this.timeouts.textarea = setTimeout(() => {
-                            this.timeouts.textarea = null;
+                        this.timeouts["textarea"] = setTimeout(() => {
+                            this.timeouts["textarea"] = null;
                             this.init();
                         }, 100);
                     }
                 });
-                observer.observe(this.target, {
-                    attributes: true,
-                    attributeFilter: ["style"],
-                });
+                observer.observe(this.target, {attributes: true, attributeFilter: ["style"]});
             }
         },
         // You can define any other Alpine.js functions here.
@@ -124,7 +112,7 @@ function stepComponent({
             window.scrollTo({
                 top: rect[0].y - window.innerHeight / 3,
                 left: rect[0].x,
-                behavior: "smooth",
+                behavior: "smooth"
             });
             const width = rect[1].x - rect[0].x;
             const height = rect[2].y - rect[0].y;
@@ -133,19 +121,16 @@ function stepComponent({
             dialog.style.width = `${width}px`;
             dialog.style.transform = `translate(${x}px, ${y}px)`;
             stroke.style.height = `${height}px`;
-            dialogPath.setAttribute(
-                "d",
-                this.elementPath(null, { relative: true, positive: true }),
-            );
+            dialogPath.setAttribute("d", this.elementPath(null, {relative: true, positive: true}));
         },
         clipPath: function (element = null, options = {}) {
             element = element || this.target;
             options = {
                 radius: 24,
                 margin: 10,
-                offset: { x: 0, y: 0 },
+                offset: {x: 0, y: 0},
                 relative: false,
-                ...options,
+                ...options
             };
             return `${this.windowPath()} ${this.elementPath(element, options)}`.trim();
         },
@@ -153,7 +138,7 @@ function stepComponent({
             const documentHeight = Math.max(
                 document.documentElement.clientHeight,
                 document.documentElement.scrollHeight,
-                document.documentElement.offsetHeight,
+                document.documentElement.offsetHeight
             );
             let path = "M 0 0 ";
             path += "L 0 " + documentHeight + " ";
@@ -163,87 +148,29 @@ function stepComponent({
             return path.trim();
         },
         findElement: function (name) {
-            const escapedSelector = selector
-                .replace(/\\/g, "\\\\")
-                .replace(/\./g, "\\$&");
-            return (
-                document.querySelector(escapedSelector) ??
-                document.querySelector(selector)
-            );
+            return document.querySelector(selector.replace(/\./g, "\\$&")) ?? document.querySelector(selector);
         },
         elementPath: function (element = null, options = {}) {
             element = element || this.target;
             options = {
                 radius: 24,
                 margin: 10,
-                offset: { x: 0, y: 0 },
-                ...options,
+                offset: {x: 0, y: 0},
+                ...options
             };
             const rect = this.elementRect(element, {
                 relative: false,
-                ...options,
+                ...options
             });
             let path = "";
             path += "M " + rect[0].x + " " + (rect[0].y + options.radius) + " ";
-            path +=
-                "C " +
-                rect[0].x +
-                " " +
-                rect[0].y +
-                " " +
-                rect[0].x +
-                " " +
-                rect[0].y +
-                " " +
-                (rect[0].x + options.radius) +
-                " " +
-                rect[0].y +
-                " ";
+            path += "C " + rect[0].x + " " + rect[0].y + " " + rect[0].x + " " + rect[0].y + " " + (rect[0].x + options.radius) + " " + rect[0].y + " ";
             path += "L " + (rect[1].x - options.radius) + " " + rect[1].y + " ";
-            path +=
-                "C " +
-                rect[1].x +
-                " " +
-                rect[1].y +
-                " " +
-                rect[1].x +
-                " " +
-                rect[1].y +
-                " " +
-                rect[1].x +
-                " " +
-                (rect[1].y + options.radius) +
-                " ";
+            path += "C " + rect[1].x + " " + rect[1].y + " " + rect[1].x + " " + rect[1].y + " " + rect[1].x + " " + (rect[1].y + options.radius) + " ";
             path += "L " + rect[2].x + " " + (rect[2].y - options.radius) + " ";
-            path +=
-                "C " +
-                rect[2].x +
-                " " +
-                rect[2].y +
-                " " +
-                rect[2].x +
-                " " +
-                rect[2].y +
-                " " +
-                (rect[2].x - options.radius) +
-                " " +
-                rect[2].y +
-                " ";
+            path += "C " + rect[2].x + " " + rect[2].y + " " + rect[2].x + " " + rect[2].y + " " + (rect[2].x - options.radius) + " " + rect[2].y + " ";
             path += "L " + (rect[3].x + options.radius) + " " + rect[3].y + " ";
-            path +=
-                "C " +
-                rect[3].x +
-                " " +
-                rect[3].y +
-                " " +
-                rect[3].x +
-                " " +
-                rect[3].y +
-                " " +
-                rect[3].x +
-                " " +
-                (rect[3].y - options.radius) +
-                " ";
+            path += "C " + rect[3].x + " " + rect[3].y + " " + rect[3].x + " " + rect[3].y + " " + rect[3].x + " " + (rect[3].y - options.radius) + " ";
             path += "L " + rect[0].x + " " + (rect[0].y + options.radius) + " ";
             return path.trim();
         },
@@ -253,45 +180,29 @@ function stepComponent({
             options = {
                 radius: 24,
                 margin: 10,
-                offset: { x: 0, y: 0 },
+                offset: {x: 0, y: 0},
                 relative: false,
-                ...options,
+                ...options
             };
             const left = options.relative ? 0 : bounds.left;
             const top = options.relative ? 0 : element.offsetTop;
-            const result = [
+            let result = [
                 {
                     x: left - options.margin + options.offset.x,
-                    y: top - options.margin + options.offset.y,
+                    y: top - options.margin + options.offset.y
                 },
                 {
-                    x:
-                        left +
-                        element.clientWidth +
-                        options.margin +
-                        options.offset.x,
-                    y: top - options.margin + options.offset.y,
+                    x: left + element.clientWidth + options.margin + options.offset.x,
+                    y: top - options.margin + options.offset.y
                 },
                 {
-                    x:
-                        left +
-                        element.clientWidth +
-                        options.margin +
-                        options.offset.x,
-                    y:
-                        top +
-                        element.clientHeight +
-                        options.margin +
-                        options.offset.y,
+                    x: left + element.clientWidth + options.margin + options.offset.x,
+                    y: top + element.clientHeight + options.margin + options.offset.y
                 },
                 {
                     x: left - options.margin + options.offset.x,
-                    y:
-                        top +
-                        element.clientHeight +
-                        options.margin +
-                        options.offset.y,
-                },
+                    y: top + element.clientHeight + options.margin + options.offset.y
+                }
             ];
             if (options.positive) {
                 let minX = 0;
@@ -310,8 +221,11 @@ function stepComponent({
                 }
             }
             return result;
-        },
+        }
     };
 }
-export { stepComponent as default };
-// # sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vY29tcG9uZW50cy9zdGVwLmpzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJleHBvcnQgZGVmYXVsdCBmdW5jdGlvbiBzdGVwQ29tcG9uZW50KHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGtleSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHNlbGVjdG9yLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgc2hvdWxkSW50ZXJjZXB0Q2xpY2ssXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpbnRlcmNlcHRDbGlja0FjdGlvbixcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgfSkge1xuICAgIHJldHVybiB7XG4gICAgICAgIHRhcmdldDogbnVsbCxcblxuICAgICAgICBzbGVlcDogZnVuY3Rpb24gKG1zKSB7XG4gICAgICAgICAgICByZXR1cm4gbmV3IFByb21pc2UocmVzb2x2ZSA9PiBzZXRUaW1lb3V0KHJlc29sdmUsIG1zKSk7XG4gICAgICAgIH0sXG5cbiAgICAgICAgaW5pdDogYXN5bmMgZnVuY3Rpb24gKCkge1xuICAgICAgICAgICAgdGhpcy50YXJnZXQgPSB0aGlzLmZpbmRFbGVtZW50KGtleSk7XG5cbiAgICAgICAgICAgIGlmICghdGhpcy50YXJnZXQpIHtcbiAgICAgICAgICAgICAgICBjb25zb2xlLmVycm9yKCdUdXRvcmlhbCBzdGVwIHdhcyBub3QgZm91bmQ6Jywga2V5KTtcbiAgICAgICAgICAgICAgICByZXR1cm47XG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIC8vIHdpbmRvdy5ibHVyKCk7XG4gICAgICAgICAgICAvLyBkb2N1bWVudC5kb2N1bWVudEVsZW1lbnQuYmx1cigpO1xuICAgICAgICAgICAgZG9jdW1lbnQuZG9jdW1lbnRFbGVtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJ2lucHV0JylcbiAgICAgICAgICAgICAgICAuZm9yRWFjaCgoZWxlbWVudCkgPT4gZWxlbWVudC5ibHVyKCkpO1xuICAgICAgICAgICAgaWYgKHRoaXMudGFyZ2V0KSB7XG4gICAgICAgICAgICAgICAgdGhpcy50YXJnZXQuZm9jdXMoKTtcbiAgICAgICAgICAgIH1cblxuICAgICAgICAgICAgdGhpcy5jb25maWd1cmUoKTtcblxuICAgICAgICAgICAgY29uc3QgZGlhbG9nID0gdGhpcy4kZWwucXVlcnlTZWxlY3RvcignW2RhdGEtZGlhbG9nXScpO1xuICAgICAgICAgICAgY29uc3QgY2xpcFBhdGggPSB0aGlzLiRlbC5xdWVyeVNlbGVjdG9yKCdbZGF0YS1jbGlwLXBhdGhdJyk7XG5cbiAgICAgICAgICAgIGlmIChzaG91bGRJbnRlcmNlcHRDbGljaykge1xuICAgICAgICAgICAgICAgIHRoaXMudGFyZ2V0LmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKGV2ZW50KSA9PiB7XG4gICAgICAgICAgICAgICAgICAgIGV2ZW50LnByZXZlbnREZWZhdWx0KCk7XG4gICAgICAgICAgICAgICAgICAgIHRoaXMuJHdpcmUuY2FsbChpbnRlcmNlcHRDbGlja0FjdGlvbik7XG5cbiAgICAgICAgICAgICAgICAgICAgdGhpcy50YXJnZXQuYmx1cigpO1xuICAgICAgICAgICAgICAgICAgICBjb25zdCBkZXNjZW5kYW50cyA9IHRoaXMudGFyZ2V0LnF1ZXJ5U2VsZWN0b3JBbGwoXCI6aG92ZXJcIik7XG5cbiAgICAgICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCBkZXNjZW5kYW50cy5sZW5ndGg7IGkrKykge1xuICAgICAgICAgICAgICAgICAgICAgICAgY29uc3QgZGVzY2VuZGFudCA9IGRlc2NlbmRhbnRzW2ldO1xuICAgICAgICAgICAgICAgICAgICAgICAgZGVzY2VuZGFudC5ibHVyKCk7XG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICB9KTtcbiAgICAgICAgICAgIH1cblxuICAgICAgICAgICAgdGhpcy5pbml0aWFsaXplRGlhbG9nKCk7XG5cbiAgICAgICAgICAgIHRoaXMuJG5leHRUaWNrKCgpID0+IHtcbiAgICAgICAgICAgICAgICBjbGlwUGF0aC5zZXRBdHRyaWJ1dGUoJ2QnLCB0aGlzLmNsaXBQYXRoKCkpO1xuICAgICAgICAgICAgICAgIHRoaXMuJGRpc3BhdGNoKCd0dXRvcmlhbDo6cmVuZGVyJyk7XG4gICAgICAgICAgICB9KTtcblxuICAgICAgICAgICAgY2xpcFBhdGguc2V0QXR0cmlidXRlKCdkJywgdGhpcy5jbGlwUGF0aCgpKTtcbiAgICAgICAgfSxcblxuICAgICAgICB0aW1lb3V0czogW10sXG5cbiAgICAgICAgY29uZmlndXJlOiBmdW5jdGlvbiAoKSB7XG4gICAgICAgICAgICBkb2N1bWVudC5hZGRFdmVudExpc3RlbmVyKCdrZXlkb3duJywgZnVuY3Rpb24gKGV2ZW50KSB7XG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBrZXkgY29kZSBvZiB0aGUga2V5IHByZXNzZWRcbiAgICAgICAgICAgICAgICB2YXIga2V5ID0gZXZlbnQua2V5O1xuXG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBzdGF0ZSBvZiB0aGUgbW9kaWZpZXIga2V5c1xuICAgICAgICAgICAgICAgIC8vIHZhciBpc0N0cmxLZXkgPSBldmVudC5jdHJsS2V5IHx8IGV2ZW50Lm1ldGFLZXk7XG4gICAgICAgICAgICAgICAgLy8gdmFyIGlzQWx0S2V5ID0gZXZlbnQuYWx0S2V5O1xuICAgICAgICAgICAgICAgIHZhciBpc1NoaWZ0S2V5ID0gZXZlbnQuc2hpZnRLZXk7XG4gICAgICAgICAgICAgICAgdmFyIGlzQ3RybEtleSA9IGZhbHNlO1xuICAgICAgICAgICAgICAgIHZhciBpc0FsdEtleSA9IGZhbHNlO1xuXG4gICAgICAgICAgICAgICAgLy8gQ2hlY2sgaWYgYW55IGNvbWJpbmF0aW9uIG9mIG1vZGlmaWVyIGtleXMgYW5kIG5vcm1hbCBrZXlzIHdlcmUgcHJlc3NlZFxuICAgICAgICAgICAgICAgIC8vIGlmIChpc0N0cmxLZXkgfHwgaXNBbHRLZXkgfHwgaXNTaGlmdEtleSB8fCBrZXkgPT09ICdUYWInKSB7XG4gICAgICAgICAgICAgICAgLy8gaWYgKGtleSA9PT0gJ1RhYicgfHwgaXNTaGlmdEtleSAmJiBrZXkgPT09ICdUYWInKSB7XG4gICAgICAgICAgICAgICAgaWYgKGtleSA9PT0gJ1RhYicpIHtcbiAgICAgICAgICAgICAgICAgICAgZXZlbnQucHJldmVudERlZmF1bHQoKTsgLy8gUHJldmVudCB0aGUgZGVmYXVsdCBldmVudCBiZWhhdmlvclxuICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgIH0pO1xuXG5cbiAgICAgICAgICAgIGlmICh0aGlzLnRhcmdldCBpbnN0YW5jZW9mIEhUTUxTZWxlY3RFbGVtZW50KSB7XG4gICAgICAgICAgICAgICAgaWYgKHRoaXMudGFyZ2V0Lmhhc0F0dHJpYnV0ZSgnZGF0YS1jaG9pY2UnKSkge1xuICAgICAgICAgICAgICAgICAgICB0aGlzLnRhcmdldCA9IHRoaXMudGFyZ2V0LnBhcmVudEVsZW1lbnQucGFyZW50RWxlbWVudDtcbiAgICAgICAgICAgICAgICAgICAgY29uc3QgZHJvcGRvd24gPSB0aGlzLnRhcmdldC5xdWVyeVNlbGVjdG9yKCcuY2hvaWNlc19fbGlzdC5jaG9pY2VzX19saXN0LS1kcm9wZG93bicpO1xuICAgICAgICAgICAgICAgICAgICBkcm9wZG93bi5zdHlsZS56SW5kZXggPSAxMDA7XG4gICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICBpZiAodGhpcy50YXJnZXQudGFnTmFtZSA9PT0gJ1RSSVgtRURJVE9SJykge1xuICAgICAgICAgICAgICAgIHRoaXMudGltZW91dHNbJ3RyaXgnXSA9IHRoaXMudGFyZ2V0LmNsaWVudEhlaWdodDtcbiAgICAgICAgICAgICAgICB0aGlzLnRhcmdldCA9IHRoaXMudGFyZ2V0LnBhcmVudEVsZW1lbnQ7XG5cbiAgICAgICAgICAgICAgICBjb25zdCBvYnNlcnZlciA9IG5ldyBNdXRhdGlvbk9ic2VydmVyKChtdXRhdGlvbnNMaXN0LCBvYnNlcnZlcikgPT4ge1xuXG4gICAgICAgICAgICAgICAgICAgIG11dGF0aW9uc0xpc3QuZm9yRWFjaCgobXV0YXRpb24pID0+IHtcblxuICAgICAgICAgICAgICAgICAgICAgICAgaWYgKHRoaXMudGltZW91dHNbJ3RyaXgnXSkge1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNsZWFyVGltZW91dCh0aGlzLnRpbWVvdXRzWyd0cml4J10pO1xuICAgICAgICAgICAgICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0cml4J10gPSBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0cml4J10gPSBudWxsO1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMuaW5pdCgpO1xuICAgICAgICAgICAgICAgICAgICAgICAgfSwgNTAwKTtcbiAgICAgICAgICAgICAgICAgICAgfSk7XG4gICAgICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgICAgICBjb25zdCBjb25maWcgPSB7XG4gICAgICAgICAgICAgICAgICAgIGF0dHJpYnV0ZXM6IHRydWUsXG4gICAgICAgICAgICAgICAgICAgIGF0dHJpYnV0ZUZpbHRlcjogWydoZWlnaHQnXSxcbiAgICAgICAgICAgICAgICAgICAgY2hpbGRMaXN0OiB0cnVlLFxuICAgICAgICAgICAgICAgICAgICBzdWJ0cmVlOiB0cnVlLFxuICAgICAgICAgICAgICAgIH07XG5cbiAgICAgICAgICAgICAgICBvYnNlcnZlci5vYnNlcnZlKHRoaXMudGFyZ2V0LCBjb25maWcpO1xuXG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIGlmICh0aGlzLnRhcmdldCBpbnN0YW5jZW9mIEhUTUxUZXh0QXJlYUVsZW1lbnQgfHwgdGhpcy50KSB7XG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBpbml0aWFsIHNpemUgb2YgdGhlIHRleHRhcmVhXG4gICAgICAgICAgICAgICAgbGV0IGluaXRpYWxXaWR0aCA9IHRoaXMudGFyZ2V0Lm9mZnNldFdpZHRoO1xuICAgICAgICAgICAgICAgIGxldCBpbml0aWFsSGVpZ2h0ID0gdGhpcy50YXJnZXQub2Zmc2V0SGVpZ2h0O1xuXG4gICAgICAgICAgICAgICAgLy8gQ3JlYXRlIGEgTXV0YXRpb25PYnNlcnZlciB0byBtb25pdG9yIHNpemUgY2hhbmdlc1xuICAgICAgICAgICAgICAgIGNvbnN0IG9ic2VydmVyID0gbmV3IE11dGF0aW9uT2JzZXJ2ZXIoKCkgPT4ge1xuICAgICAgICAgICAgICAgICAgICBpZiAodGhpcy50YXJnZXQub2Zmc2V0V2lkdGggIT09IGluaXRpYWxXaWR0aCB8fCB0aGlzLnRhcmdldC5vZmZzZXRIZWlnaHQgIT09IGluaXRpYWxIZWlnaHQpIHtcbiAgICAgICAgICAgICAgICAgICAgICAgIGluaXRpYWxXaWR0aCA9IHRoaXMudGFyZ2V0Lm9mZnNldFdpZHRoO1xuICAgICAgICAgICAgICAgICAgICAgICAgaW5pdGlhbEhlaWdodCA9IHRoaXMudGFyZ2V0Lm9mZnNldEhlaWdodDtcblxuICAgICAgICAgICAgICAgICAgICAgICAgaWYgKHRoaXMudGltZW91dHNbJ3RleHRhcmVhJ10pIHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICBjbGVhclRpbWVvdXQodGhpcy50aW1lb3V0c1sndGV4dGFyZWEnXSk7XG4gICAgICAgICAgICAgICAgICAgICAgICB9XG5cbiAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMudGltZW91dHNbJ3RleHRhcmVhJ10gPSBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0ZXh0YXJlYSddID0gbnVsbDtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLmluaXQoKTtcbiAgICAgICAgICAgICAgICAgICAgICAgIH0sIDEwMCk7XG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICB9KTtcblxuICAgICAgICAgICAgICAgIC8vIFN0YXJ0IG9ic2VydmluZyBjaGFuZ2VzIGluIHRoZSB0ZXh0YXJlYSBlbGVtZW50XG4gICAgICAgICAgICAgICAgb2JzZXJ2ZXIub2JzZXJ2ZSh0aGlzLnRhcmdldCwge2F0dHJpYnV0ZXM6IHRydWUsIGF0dHJpYnV0ZUZpbHRlcjogWydzdHlsZSddfSk7XG4gICAgICAgICAgICB9XG4gICAgICAgIH0sXG4gICAgICAgIC8vIFlvdSBjYW4gZGVmaW5lIGFueSBvdGhlciBBbHBpbmUuanMgZnVuY3Rpb25zIGhlcmUuXG5cbiAgICAgICAgaW5pdGlhbGl6ZURpYWxvZzogZnVuY3Rpb24gKGRpYWxvZyA9IG51bGwpIHtcbiAgICAgICAgICAgIGlmICghZGlhbG9nKSB7XG4gICAgICAgICAgICAgICAgZGlhbG9nID0gdGhpcy4kZWwucXVlcnlTZWxlY3RvcignW2RhdGEtZGlhbG9nXScpO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgZGlhbG9nUGF0aCA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCdbZGF0YS1kaWFsb2ctcGF0aF0nKTtcblxuICAgICAgICAgICAgY29uc3QgcmVjdCA9IHRoaXMuZWxlbWVudFJlY3QoKTtcbiAgICAgICAgICAgIC8vIGNvbnN0IGhlYWRlciA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCdbZGF0YS1kaWFsb2ctaGVhZGVyXScpO1xuICAgICAgICAgICAgY29uc3Qgc3Ryb2tlID0gZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJ1tkYXRhLWRpYWxvZy1zdHJva2VdJyk7XG5cbiAgICAgICAgICAgIHdpbmRvdy5zY3JvbGxUbyh7XG4gICAgICAgICAgICAgICAgdG9wOiByZWN0WzBdLnkgLSAod2luZG93LmlubmVySGVpZ2h0IC8gMyksXG4gICAgICAgICAgICAgICAgbGVmdDogcmVjdFswXS54LFxuICAgICAgICAgICAgICAgIGJlaGF2aW9yOiAnc21vb3RoJ1xuICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgIGNvbnN0IHdpZHRoID0gcmVjdFsxXS54IC0gcmVjdFswXS54O1xuICAgICAgICAgICAgY29uc3QgaGVpZ2h0ID0gcmVjdFsyXS55IC0gcmVjdFswXS55O1xuXG4gICAgICAgICAgICBjb25zdCB4ID0gcmVjdFswXS54O1xuICAgICAgICAgICAgY29uc3QgeSA9IHJlY3RbMF0ueTtcbiAgICAgICAgICAgIGRpYWxvZy5zdHlsZS53aWR0aCA9IGAke3dpZHRofXB4YDtcbiAgICAgICAgICAgIGRpYWxvZy5zdHlsZS50cmFuc2Zvcm0gPSBgdHJhbnNsYXRlKCR7eH1weCwgJHt5fXB4KWA7XG4gICAgICAgICAgICBzdHJva2Uuc3R5bGUuaGVpZ2h0ID0gYCR7aGVpZ2h0fXB4YDtcblxuICAgICAgICAgICAgZGlhbG9nUGF0aC5zZXRBdHRyaWJ1dGUoJ2QnLCB0aGlzLmVsZW1lbnRQYXRoKG51bGwsIHtyZWxhdGl2ZTogdHJ1ZSwgcG9zaXRpdmU6IHRydWV9KSlcbiAgICAgICAgfSxcblxuICAgICAgICBjbGlwUGF0aDogZnVuY3Rpb24gKGVsZW1lbnQgPSBudWxsLCBvcHRpb25zID0ge30pIHtcbiAgICAgICAgICAgIGVsZW1lbnQgPSBlbGVtZW50IHx8IHRoaXMudGFyZ2V0O1xuICAgICAgICAgICAgb3B0aW9ucyA9IHtcbiAgICAgICAgICAgICAgICByYWRpdXM6IDI0LFxuICAgICAgICAgICAgICAgIG1hcmdpbjogMTAsXG4gICAgICAgICAgICAgICAgb2Zmc2V0OiB7eDogMCwgeTogMH0sXG4gICAgICAgICAgICAgICAgcmVsYXRpdmU6IGZhbHNlLFxuICAgICAgICAgICAgICAgIC4uLm9wdGlvbnNcbiAgICAgICAgICAgIH1cbiAgICAgICAgICAgIHJldHVybiBgJHt0aGlzLndpbmRvd1BhdGgoKX0gJHt0aGlzLmVsZW1lbnRQYXRoKGVsZW1lbnQsIG9wdGlvbnMpfWAudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIHdpbmRvd1BhdGg6IGZ1bmN0aW9uICgpIHtcbiAgICAgICAgICAgIGNvbnN0IGRvY3VtZW50SGVpZ2h0ID0gTWF0aC5tYXgoXG4gICAgICAgICAgICAgICAgZG9jdW1lbnQuZG9jdW1lbnRFbGVtZW50LmNsaWVudEhlaWdodCxcbiAgICAgICAgICAgICAgICBkb2N1bWVudC5kb2N1bWVudEVsZW1lbnQuc2Nyb2xsSGVpZ2h0LFxuICAgICAgICAgICAgICAgIGRvY3VtZW50LmRvY3VtZW50RWxlbWVudC5vZmZzZXRIZWlnaHQsXG4gICAgICAgICAgICApO1xuXG4gICAgICAgICAgICAvLyBUT0RPOiBhZGQgb3B0aW9uIHRvIHNlbGVjdCBjbG9ja3dpc2UgL2NvdW50ZXIgY2xvY2t3aXNlXG4gICAgICAgICAgICAvL00gMCA4IEMgMCAwIDAgMCA4IDAgTCAzOCAwIEMgNDYgMCA0NiAwIDQ2IDggQyA0NiAxNiA0NiAxNiAzOCAxNiBMIDggMTYgQyAwIDE2IDAgMTYgMCA4XG4gICAgICAgICAgICBsZXQgcGF0aCA9ICdNIDAgMCAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAwICcgKyBkb2N1bWVudEhlaWdodCArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0wgJyArIHdpbmRvdy5pbm5lcldpZHRoICsgJyAnICsgZG9jdW1lbnRIZWlnaHQgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdMICcgKyB3aW5kb3cuaW5uZXJXaWR0aCArICcgMCAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAwIDAgJztcblxuICAgICAgICAgICAgcmV0dXJuIHBhdGgudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIGZpbmRFbGVtZW50OiBmdW5jdGlvbiAobmFtZSkge1xuICAgICAgICAgICAgcmV0dXJuIGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3Ioc2VsZWN0b3IucmVwbGFjZSgvXFwuL2csICdcXFxcJCYnKSlcbiAgICAgICAgICAgICAgICA/PyBkb2N1bWVudC5xdWVyeVNlbGVjdG9yKHNlbGVjdG9yKTtcbiAgICAgICAgfSxcblxuICAgICAgICBlbGVtZW50UGF0aDogZnVuY3Rpb24gKGVsZW1lbnQgPSBudWxsLCBvcHRpb25zID0ge30pIHtcbiAgICAgICAgICAgIGVsZW1lbnQgPSBlbGVtZW50IHx8IHRoaXMudGFyZ2V0O1xuICAgICAgICAgICAgb3B0aW9ucyA9IHtcbiAgICAgICAgICAgICAgICByYWRpdXM6IDI0LFxuICAgICAgICAgICAgICAgIG1hcmdpbjogMTAsXG4gICAgICAgICAgICAgICAgb2Zmc2V0OiB7eDogMCwgeTogMH0sXG4gICAgICAgICAgICAgICAgLi4ub3B0aW9uc1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgcmVjdCA9IHRoaXMuZWxlbWVudFJlY3QoZWxlbWVudCwge1xuICAgICAgICAgICAgICAgIHJlbGF0aXZlOiBmYWxzZSxcbiAgICAgICAgICAgICAgICAuLi5vcHRpb25zLFxuICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgIGxldCBwYXRoID0gJyc7XG4gICAgICAgICAgICBwYXRoICs9ICdNICcgKyByZWN0WzBdLnggKyAnICcgKyAocmVjdFswXS55ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnQyAnICsgcmVjdFswXS54ICsgJyAnICsgcmVjdFswXS55ICsgJyAnICsgcmVjdFswXS54ICsgJyAnICsgcmVjdFswXS55ICsgJyAnICsgKHJlY3RbMF0ueCArIG9wdGlvbnMucmFkaXVzKSArICcgJyArIHJlY3RbMF0ueSArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0wgJyArIChyZWN0WzFdLnggLSBvcHRpb25zLnJhZGl1cykgKyAnICcgKyByZWN0WzFdLnkgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdDICcgKyByZWN0WzFdLnggKyAnICcgKyByZWN0WzFdLnkgKyAnICcgKyByZWN0WzFdLnggKyAnICcgKyByZWN0WzFdLnkgKyAnICcgKyByZWN0WzFdLnggKyAnICcgKyAocmVjdFsxXS55ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAnICsgcmVjdFsyXS54ICsgJyAnICsgKHJlY3RbMl0ueSAtIG9wdGlvbnMucmFkaXVzKSArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0MgJyArIHJlY3RbMl0ueCArICcgJyArIHJlY3RbMl0ueSArICcgJyArIHJlY3RbMl0ueCArICcgJyArIHJlY3RbMl0ueSArICcgJyArIChyZWN0WzJdLnggLSBvcHRpb25zLnJhZGl1cykgKyAnICcgKyByZWN0WzJdLnkgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdMICcgKyAocmVjdFszXS54ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnICsgcmVjdFszXS55ICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnQyAnICsgcmVjdFszXS54ICsgJyAnICsgcmVjdFszXS55ICsgJyAnICsgcmVjdFszXS54ICsgJyAnICsgcmVjdFszXS55ICsgJyAnICsgcmVjdFszXS54ICsgJyAnICsgKHJlY3RbM10ueSAtIG9wdGlvbnMucmFkaXVzKSArICcgJztcbiAgICAgICAgICAgIC8vIHBhdGggKz0gJ1onO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAnICsgcmVjdFswXS54ICsgJyAnICsgKHJlY3RbMF0ueSArIG9wdGlvbnMucmFkaXVzKSArICcgJztcblxuICAgICAgICAgICAgcmV0dXJuIHBhdGgudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIGVsZW1lbnRSZWN0OiBmdW5jdGlvbiAoZWxlbWVudCA9IG51bGwsIG9wdGlvbnMgPSB7fSkge1xuXG4gICAgICAgICAgICBlbGVtZW50ID0gZWxlbWVudCB8fCB0aGlzLnRhcmdldDtcbiAgICAgICAgICAgIGNvbnN0IGJvdW5kcyA9IGVsZW1lbnQuZ2V0Qm91bmRpbmdDbGllbnRSZWN0KCk7XG4gICAgICAgICAgICBvcHRpb25zID0ge1xuICAgICAgICAgICAgICAgIHJhZGl1czogMjQsXG4gICAgICAgICAgICAgICAgbWFyZ2luOiAxMCxcbiAgICAgICAgICAgICAgICBvZmZzZXQ6IHt4OiAwLCB5OiAwfSxcbiAgICAgICAgICAgICAgICByZWxhdGl2ZTogZmFsc2UsXG4gICAgICAgICAgICAgICAgLi4ub3B0aW9uc1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgbGVmdCA9IG9wdGlvbnMucmVsYXRpdmUgPyAwIDogYm91bmRzLmxlZnQ7XG4gICAgICAgICAgICBjb25zdCB0b3AgPSBvcHRpb25zLnJlbGF0aXZlID8gMCA6IGVsZW1lbnQub2Zmc2V0VG9wO1xuXG4gICAgICAgICAgICBsZXQgcmVzdWx0ID0gW1xuICAgICAgICAgICAgICAgIHtcbiAgICAgICAgICAgICAgICAgICAgeDogbGVmdCAtIG9wdGlvbnMubWFyZ2luICsgb3B0aW9ucy5vZmZzZXQueCxcbiAgICAgICAgICAgICAgICAgICAgeTogdG9wIC0gb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfSxcbiAgICAgICAgICAgICAgICB7XG4gICAgICAgICAgICAgICAgICAgIHg6IGxlZnQgKyBlbGVtZW50LmNsaWVudFdpZHRoICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC54LFxuICAgICAgICAgICAgICAgICAgICB5OiB0b3AgLSBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LnlcbiAgICAgICAgICAgICAgICB9LFxuICAgICAgICAgICAgICAgIHtcbiAgICAgICAgICAgICAgICAgICAgeDogbGVmdCArIGVsZW1lbnQuY2xpZW50V2lkdGggKyBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LngsXG4gICAgICAgICAgICAgICAgICAgIHk6IHRvcCArIGVsZW1lbnQuY2xpZW50SGVpZ2h0ICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfSxcbiAgICAgICAgICAgICAgICB7XG4gICAgICAgICAgICAgICAgICAgIHg6IGxlZnQgLSBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LngsXG4gICAgICAgICAgICAgICAgICAgIHk6IHRvcCArIGVsZW1lbnQuY2xpZW50SGVpZ2h0ICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgXTtcblxuICAgICAgICAgICAgaWYgKG9wdGlvbnMucG9zaXRpdmUpIHtcbiAgICAgICAgICAgICAgICBsZXQgbWluWCA9IDA7XG4gICAgICAgICAgICAgICAgbGV0IG1pblkgPSAwO1xuXG4gICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCByZXN1bHQubGVuZ3RoOyBpKyspIHtcbiAgICAgICAgICAgICAgICAgICAgaWYgKHJlc3VsdFtpXS54IDwgbWluWCkge1xuICAgICAgICAgICAgICAgICAgICAgICAgbWluWCA9IHJlc3VsdFtpXS54O1xuICAgICAgICAgICAgICAgICAgICB9XG5cbiAgICAgICAgICAgICAgICAgICAgaWYgKHJlc3VsdFtpXS55IDwgbWluWSkge1xuICAgICAgICAgICAgICAgICAgICAgICAgbWluWSA9IHJlc3VsdFtpXS55O1xuICAgICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCByZXN1bHQubGVuZ3RoOyBpKyspIHtcbiAgICAgICAgICAgICAgICAgICAgcmVzdWx0W2ldLnggLT0gbWluWDtcbiAgICAgICAgICAgICAgICAgICAgcmVzdWx0W2ldLnkgLT0gbWluWTtcbiAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIHJldHVybiByZXN1bHQ7XG4gICAgICAgIH1cbiAgICB9XG59Il0sCiAgIm1hcHBpbmdzIjogIjtBQUFlLFNBQVIsY0FBK0I7QUFBQSxFQUNJO0FBQUEsRUFDQTtBQUFBLEVBQ0E7QUFBQSxFQUNBO0FBQ0osR0FBRztBQUNyQyxTQUFPO0FBQUEsSUFDSCxRQUFRO0FBQUEsSUFFUixPQUFPLFNBQVUsSUFBSTtBQUNqQixhQUFPLElBQUksUUFBUSxhQUFXLFdBQVcsU0FBUyxFQUFFLENBQUM7QUFBQSxJQUN6RDtBQUFBLElBRUEsTUFBTSxpQkFBa0I7QUFDcEIsV0FBSyxTQUFTLEtBQUssWUFBWSxHQUFHO0FBRWxDLFVBQUksQ0FBQyxLQUFLLFFBQVE7QUFDZCxnQkFBUSxNQUFNLGdDQUFnQyxHQUFHO0FBQ2pEO0FBQUEsTUFDSjtBQUlBLGVBQVMsZ0JBQWdCLGlCQUFpQixPQUFPLEVBQzVDLFFBQVEsQ0FBQyxZQUFZLFFBQVEsS0FBSyxDQUFDO0FBQ3hDLFVBQUksS0FBSyxRQUFRO0FBQ2IsYUFBSyxPQUFPLE1BQU07QUFBQSxNQUN0QjtBQUVBLFdBQUssVUFBVTtBQUVmLFlBQU0sU0FBUyxLQUFLLElBQUksY0FBYyxlQUFlO0FBQ3JELFlBQU0sV0FBVyxLQUFLLElBQUksY0FBYyxrQkFBa0I7QUFFMUQsVUFBSSxzQkFBc0I7QUFDdEIsYUFBSyxPQUFPLGlCQUFpQixTQUFTLENBQUMsVUFBVTtBQUM3QyxnQkFBTSxlQUFlO0FBQ3JCLGVBQUssTUFBTSxLQUFLLG9CQUFvQjtBQUVwQyxlQUFLLE9BQU8sS0FBSztBQUNqQixnQkFBTSxjQUFjLEtBQUssT0FBTyxpQkFBaUIsUUFBUTtBQUV6RCxtQkFBUyxJQUFJLEdBQUcsSUFBSSxZQUFZLFFBQVEsS0FBSztBQUN6QyxrQkFBTSxhQUFhLFlBQVksQ0FBQztBQUNoQyx1QkFBVyxLQUFLO0FBQUEsVUFDcEI7QUFBQSxRQUNKLENBQUM7QUFBQSxNQUNMO0FBRUEsV0FBSyxpQkFBaUI7QUFFdEIsV0FBSyxVQUFVLE1BQU07QUFDakIsaUJBQVMsYUFBYSxLQUFLLEtBQUssU0FBUyxDQUFDO0FBQzFDLGFBQUssVUFBVSxrQkFBa0I7QUFBQSxNQUNyQyxDQUFDO0FBRUQsZUFBUyxhQUFhLEtBQUssS0FBSyxTQUFTLENBQUM7QUFBQSxJQUM5QztBQUFBLElBRUEsVUFBVSxDQUFDO0FBQUEsSUFFWCxXQUFXLFdBQVk7QUFDbkIsZUFBUyxpQkFBaUIsV0FBVyxTQUFVLE9BQU87QUFFbEQsWUFBSUEsT0FBTSxNQUFNO0FBS2hCLFlBQUksYUFBYSxNQUFNO0FBQ3ZCLFlBQUksWUFBWTtBQUNoQixZQUFJLFdBQVc7QUFLZixZQUFJQSxTQUFRLE9BQU87QUFDZixnQkFBTSxlQUFlO0FBQUEsUUFDekI7QUFBQSxNQUNKLENBQUM7QUFHRCxVQUFJLEtBQUssa0JBQWtCLG1CQUFtQjtBQUMxQyxZQUFJLEtBQUssT0FBTyxhQUFhLGFBQWEsR0FBRztBQUN6QyxlQUFLLFNBQVMsS0FBSyxPQUFPLGNBQWM7QUFDeEMsZ0JBQU0sV0FBVyxLQUFLLE9BQU8sY0FBYyx3Q0FBd0M7QUFDbkYsbUJBQVMsTUFBTSxTQUFTO0FBQUEsUUFDNUI7QUFBQSxNQUNKO0FBRUEsVUFBSSxLQUFLLE9BQU8sWUFBWSxlQUFlO0FBQ3ZDLGFBQUssU0FBUyxNQUFNLElBQUksS0FBSyxPQUFPO0FBQ3BDLGFBQUssU0FBUyxLQUFLLE9BQU87QUFFMUIsY0FBTSxXQUFXLElBQUksaUJBQWlCLENBQUMsZUFBZUMsY0FBYTtBQUUvRCx3QkFBYyxRQUFRLENBQUMsYUFBYTtBQUVoQyxnQkFBSSxLQUFLLFNBQVMsTUFBTSxHQUFHO0FBQ3ZCLDJCQUFhLEtBQUssU0FBUyxNQUFNLENBQUM7QUFBQSxZQUN0QztBQUVBLGlCQUFLLFNBQVMsTUFBTSxJQUFJLFdBQVcsTUFBTTtBQUNyQyxtQkFBSyxTQUFTLE1BQU0sSUFBSTtBQUN4QixtQkFBSyxLQUFLO0FBQUEsWUFDZCxHQUFHLEdBQUc7QUFBQSxVQUNWLENBQUM7QUFBQSxRQUNMLENBQUM7QUFFRCxjQUFNLFNBQVM7QUFBQSxVQUNYLFlBQVk7QUFBQSxVQUNaLGlCQUFpQixDQUFDLFFBQVE7QUFBQSxVQUMxQixXQUFXO0FBQUEsVUFDWCxTQUFTO0FBQUEsUUFDYjtBQUVBLGlCQUFTLFFBQVEsS0FBSyxRQUFRLE1BQU07QUFBQSxNQUV4QztBQUVBLFVBQUksS0FBSyxrQkFBa0IsdUJBQXVCLEtBQUssR0FBRztBQUV0RCxZQUFJLGVBQWUsS0FBSyxPQUFPO0FBQy9CLFlBQUksZ0JBQWdCLEtBQUssT0FBTztBQUdoQyxjQUFNLFdBQVcsSUFBSSxpQkFBaUIsTUFBTTtBQUN4QyxjQUFJLEtBQUssT0FBTyxnQkFBZ0IsZ0JBQWdCLEtBQUssT0FBTyxpQkFBaUIsZUFBZTtBQUN4RiwyQkFBZSxLQUFLLE9BQU87QUFDM0IsNEJBQWdCLEtBQUssT0FBTztBQUU1QixnQkFBSSxLQUFLLFNBQVMsVUFBVSxHQUFHO0FBQzNCLDJCQUFhLEtBQUssU0FBUyxVQUFVLENBQUM7QUFBQSxZQUMxQztBQUVBLGlCQUFLLFNBQVMsVUFBVSxJQUFJLFdBQVcsTUFBTTtBQUN6QyxtQkFBSyxTQUFTLFVBQVUsSUFBSTtBQUM1QixtQkFBSyxLQUFLO0FBQUEsWUFDZCxHQUFHLEdBQUc7QUFBQSxVQUNWO0FBQUEsUUFDSixDQUFDO0FBR0QsaUJBQVMsUUFBUSxLQUFLLFFBQVEsRUFBQyxZQUFZLE1BQU0saUJBQWlCLENBQUMsT0FBTyxFQUFDLENBQUM7QUFBQSxNQUNoRjtBQUFBLElBQ0o7QUFBQTtBQUFBLElBR0Esa0JBQWtCLFNBQVUsU0FBUyxNQUFNO0FBQ3ZDLFVBQUksQ0FBQyxRQUFRO0FBQ1QsaUJBQVMsS0FBSyxJQUFJLGNBQWMsZUFBZTtBQUFBLE1BQ25EO0FBQ0EsWUFBTSxhQUFhLE9BQU8sY0FBYyxvQkFBb0I7QUFFNUQsWUFBTSxPQUFPLEtBQUssWUFBWTtBQUU5QixZQUFNLFNBQVMsT0FBTyxjQUFjLHNCQUFzQjtBQUUxRCxhQUFPLFNBQVM7QUFBQSxRQUNaLEtBQUssS0FBSyxDQUFDLEVBQUUsSUFBSyxPQUFPLGNBQWM7QUFBQSxRQUN2QyxNQUFNLEtBQUssQ0FBQyxFQUFFO0FBQUEsUUFDZCxVQUFVO0FBQUEsTUFDZCxDQUFDO0FBRUQsWUFBTSxRQUFRLEtBQUssQ0FBQyxFQUFFLElBQUksS0FBSyxDQUFDLEVBQUU7QUFDbEMsWUFBTSxTQUFTLEtBQUssQ0FBQyxFQUFFLElBQUksS0FBSyxDQUFDLEVBQUU7QUFFbkMsWUFBTSxJQUFJLEtBQUssQ0FBQyxFQUFFO0FBQ2xCLFlBQU0sSUFBSSxLQUFLLENBQUMsRUFBRTtBQUNsQixhQUFPLE1BQU0sUUFBUSxHQUFHLEtBQUs7QUFDN0IsYUFBTyxNQUFNLFlBQVksYUFBYSxDQUFDLE9BQU8sQ0FBQztBQUMvQyxhQUFPLE1BQU0sU0FBUyxHQUFHLE1BQU07QUFFL0IsaUJBQVcsYUFBYSxLQUFLLEtBQUssWUFBWSxNQUFNLEVBQUMsVUFBVSxNQUFNLFVBQVUsS0FBSSxDQUFDLENBQUM7QUFBQSxJQUN6RjtBQUFBLElBRUEsVUFBVSxTQUFVLFVBQVUsTUFBTSxVQUFVLENBQUMsR0FBRztBQUM5QyxnQkFBVSxXQUFXLEtBQUs7QUFDMUIsZ0JBQVU7QUFBQSxRQUNOLFFBQVE7QUFBQSxRQUNSLFFBQVE7QUFBQSxRQUNSLFFBQVEsRUFBQyxHQUFHLEdBQUcsR0FBRyxFQUFDO0FBQUEsUUFDbkIsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1A7QUFDQSxhQUFPLEdBQUcsS0FBSyxXQUFXLENBQUMsSUFBSSxLQUFLLFlBQVksU0FBUyxPQUFPLENBQUMsR0FBRyxLQUFLO0FBQUEsSUFDN0U7QUFBQSxJQUVBLFlBQVksV0FBWTtBQUNwQixZQUFNLGlCQUFpQixLQUFLO0FBQUEsUUFDeEIsU0FBUyxnQkFBZ0I7QUFBQSxRQUN6QixTQUFTLGdCQUFnQjtBQUFBLFFBQ3pCLFNBQVMsZ0JBQWdCO0FBQUEsTUFDN0I7QUFJQSxVQUFJLE9BQU87QUFDWCxjQUFRLFNBQVMsaUJBQWlCO0FBQ2xDLGNBQVEsT0FBTyxPQUFPLGFBQWEsTUFBTSxpQkFBaUI7QUFDMUQsY0FBUSxPQUFPLE9BQU8sYUFBYTtBQUNuQyxjQUFRO0FBRVIsYUFBTyxLQUFLLEtBQUs7QUFBQSxJQUNyQjtBQUFBLElBRUEsYUFBYSxTQUFVLE1BQU07QUFDekIsYUFBTyxTQUFTLGNBQWMsU0FBUyxRQUFRLE9BQU8sTUFBTSxDQUFDLEtBQ3RELFNBQVMsY0FBYyxRQUFRO0FBQUEsSUFDMUM7QUFBQSxJQUVBLGFBQWEsU0FBVSxVQUFVLE1BQU0sVUFBVSxDQUFDLEdBQUc7QUFDakQsZ0JBQVUsV0FBVyxLQUFLO0FBQzFCLGdCQUFVO0FBQUEsUUFDTixRQUFRO0FBQUEsUUFDUixRQUFRO0FBQUEsUUFDUixRQUFRLEVBQUMsR0FBRyxHQUFHLEdBQUcsRUFBQztBQUFBLFFBQ25CLEdBQUc7QUFBQSxNQUNQO0FBQ0EsWUFBTSxPQUFPLEtBQUssWUFBWSxTQUFTO0FBQUEsUUFDbkMsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1AsQ0FBQztBQUVELFVBQUksT0FBTztBQUNYLGNBQVEsT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVU7QUFDaEUsY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUk7QUFDeEksY0FBUSxRQUFRLEtBQUssQ0FBQyxFQUFFLElBQUksUUFBUSxVQUFVLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSTtBQUNoRSxjQUFRLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVTtBQUN4SSxjQUFRLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksUUFBUSxVQUFVO0FBQ2hFLGNBQVEsT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVUsTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJO0FBQ3hJLGNBQVEsUUFBUSxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUk7QUFDaEUsY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVU7QUFFeEksY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVTtBQUVoRSxhQUFPLEtBQUssS0FBSztBQUFBLElBQ3JCO0FBQUEsSUFFQSxhQUFhLFNBQVUsVUFBVSxNQUFNLFVBQVUsQ0FBQyxHQUFHO0FBRWpELGdCQUFVLFdBQVcsS0FBSztBQUMxQixZQUFNLFNBQVMsUUFBUSxzQkFBc0I7QUFDN0MsZ0JBQVU7QUFBQSxRQUNOLFFBQVE7QUFBQSxRQUNSLFFBQVE7QUFBQSxRQUNSLFFBQVEsRUFBQyxHQUFHLEdBQUcsR0FBRyxFQUFDO0FBQUEsUUFDbkIsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1A7QUFDQSxZQUFNLE9BQU8sUUFBUSxXQUFXLElBQUksT0FBTztBQUMzQyxZQUFNLE1BQU0sUUFBUSxXQUFXLElBQUksUUFBUTtBQUUzQyxVQUFJLFNBQVM7QUFBQSxRQUNUO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFVBQzFDLEdBQUcsTUFBTSxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsUUFDN0M7QUFBQSxRQUNBO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxjQUFjLFFBQVEsU0FBUyxRQUFRLE9BQU87QUFBQSxVQUNoRSxHQUFHLE1BQU0sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFFBQzdDO0FBQUEsUUFDQTtBQUFBLFVBQ0ksR0FBRyxPQUFPLFFBQVEsY0FBYyxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsVUFDaEUsR0FBRyxNQUFNLFFBQVEsZUFBZSxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsUUFDcEU7QUFBQSxRQUNBO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFVBQzFDLEdBQUcsTUFBTSxRQUFRLGVBQWUsUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFFBQ3BFO0FBQUEsTUFDSjtBQUVBLFVBQUksUUFBUSxVQUFVO0FBQ2xCLFlBQUksT0FBTztBQUNYLFlBQUksT0FBTztBQUVYLGlCQUFTLElBQUksR0FBRyxJQUFJLE9BQU8sUUFBUSxLQUFLO0FBQ3BDLGNBQUksT0FBTyxDQUFDLEVBQUUsSUFBSSxNQUFNO0FBQ3BCLG1CQUFPLE9BQU8sQ0FBQyxFQUFFO0FBQUEsVUFDckI7QUFFQSxjQUFJLE9BQU8sQ0FBQyxFQUFFLElBQUksTUFBTTtBQUNwQixtQkFBTyxPQUFPLENBQUMsRUFBRTtBQUFBLFVBQ3JCO0FBQUEsUUFDSjtBQUVBLGlCQUFTLElBQUksR0FBRyxJQUFJLE9BQU8sUUFBUSxLQUFLO0FBQ3BDLGlCQUFPLENBQUMsRUFBRSxLQUFLO0FBQ2YsaUJBQU8sQ0FBQyxFQUFFLEtBQUs7QUFBQSxRQUNuQjtBQUFBLE1BQ0o7QUFFQSxhQUFPO0FBQUEsSUFDWDtBQUFBLEVBQ0o7QUFDSjsiLAogICJuYW1lcyI6IFsia2V5IiwgIm9ic2VydmVyIl0KfQo=
+
+export {
+    stepComponent as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsiLi4vLi4vY29tcG9uZW50cy9zdGVwLmpzIl0sCiAgInNvdXJjZXNDb250ZW50IjogWyJleHBvcnQgZGVmYXVsdCBmdW5jdGlvbiBzdGVwQ29tcG9uZW50KHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGtleSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHNlbGVjdG9yLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgc2hvdWxkSW50ZXJjZXB0Q2xpY2ssXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBpbnRlcmNlcHRDbGlja0FjdGlvbixcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgfSkge1xuICAgIHJldHVybiB7XG4gICAgICAgIHRhcmdldDogbnVsbCxcblxuICAgICAgICBzbGVlcDogZnVuY3Rpb24gKG1zKSB7XG4gICAgICAgICAgICByZXR1cm4gbmV3IFByb21pc2UocmVzb2x2ZSA9PiBzZXRUaW1lb3V0KHJlc29sdmUsIG1zKSk7XG4gICAgICAgIH0sXG5cbiAgICAgICAgaW5pdDogYXN5bmMgZnVuY3Rpb24gKCkge1xuICAgICAgICAgICAgdGhpcy50YXJnZXQgPSB0aGlzLmZpbmRFbGVtZW50KGtleSk7XG5cbiAgICAgICAgICAgIGlmICghdGhpcy50YXJnZXQpIHtcbiAgICAgICAgICAgICAgICBjb25zb2xlLmVycm9yKCdUdXRvcmlhbCBzdGVwIHdhcyBub3QgZm91bmQ6Jywga2V5KTtcbiAgICAgICAgICAgICAgICByZXR1cm47XG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIC8vIHdpbmRvdy5ibHVyKCk7XG4gICAgICAgICAgICAvLyBkb2N1bWVudC5kb2N1bWVudEVsZW1lbnQuYmx1cigpO1xuICAgICAgICAgICAgZG9jdW1lbnQuZG9jdW1lbnRFbGVtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoJ2lucHV0JylcbiAgICAgICAgICAgICAgICAuZm9yRWFjaCgoZWxlbWVudCkgPT4gZWxlbWVudC5ibHVyKCkpO1xuICAgICAgICAgICAgaWYgKHRoaXMudGFyZ2V0KSB7XG4gICAgICAgICAgICAgICAgdGhpcy50YXJnZXQuZm9jdXMoKTtcbiAgICAgICAgICAgIH1cblxuICAgICAgICAgICAgdGhpcy5jb25maWd1cmUoKTtcblxuICAgICAgICAgICAgY29uc3QgZGlhbG9nID0gdGhpcy4kZWwucXVlcnlTZWxlY3RvcignW2RhdGEtZGlhbG9nXScpO1xuICAgICAgICAgICAgY29uc3QgY2xpcFBhdGggPSB0aGlzLiRlbC5xdWVyeVNlbGVjdG9yKCdbZGF0YS1jbGlwLXBhdGhdJyk7XG5cbiAgICAgICAgICAgIGlmIChzaG91bGRJbnRlcmNlcHRDbGljaykge1xuICAgICAgICAgICAgICAgIHRoaXMudGFyZ2V0LmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKGV2ZW50KSA9PiB7XG4gICAgICAgICAgICAgICAgICAgIGV2ZW50LnByZXZlbnREZWZhdWx0KCk7XG4gICAgICAgICAgICAgICAgICAgIHRoaXMuJHdpcmUuY2FsbChpbnRlcmNlcHRDbGlja0FjdGlvbik7XG5cbiAgICAgICAgICAgICAgICAgICAgdGhpcy50YXJnZXQuYmx1cigpO1xuICAgICAgICAgICAgICAgICAgICBjb25zdCBkZXNjZW5kYW50cyA9IHRoaXMudGFyZ2V0LnF1ZXJ5U2VsZWN0b3JBbGwoXCI6aG92ZXJcIik7XG5cbiAgICAgICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCBkZXNjZW5kYW50cy5sZW5ndGg7IGkrKykge1xuICAgICAgICAgICAgICAgICAgICAgICAgY29uc3QgZGVzY2VuZGFudCA9IGRlc2NlbmRhbnRzW2ldO1xuICAgICAgICAgICAgICAgICAgICAgICAgZGVzY2VuZGFudC5ibHVyKCk7XG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICB9KTtcbiAgICAgICAgICAgIH1cblxuICAgICAgICAgICAgdGhpcy5pbml0aWFsaXplRGlhbG9nKCk7XG5cbiAgICAgICAgICAgIHRoaXMuJG5leHRUaWNrKCgpID0+IHtcbiAgICAgICAgICAgICAgICBjbGlwUGF0aC5zZXRBdHRyaWJ1dGUoJ2QnLCB0aGlzLmNsaXBQYXRoKCkpO1xuICAgICAgICAgICAgICAgIHRoaXMuJGRpc3BhdGNoKCd0dXRvcmlhbDo6cmVuZGVyJyk7XG4gICAgICAgICAgICB9KTtcblxuICAgICAgICAgICAgY2xpcFBhdGguc2V0QXR0cmlidXRlKCdkJywgdGhpcy5jbGlwUGF0aCgpKTtcbiAgICAgICAgfSxcblxuICAgICAgICB0aW1lb3V0czogW10sXG5cbiAgICAgICAgY29uZmlndXJlOiBmdW5jdGlvbiAoKSB7XG4gICAgICAgICAgICBkb2N1bWVudC5hZGRFdmVudExpc3RlbmVyKCdrZXlkb3duJywgZnVuY3Rpb24gKGV2ZW50KSB7XG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBrZXkgY29kZSBvZiB0aGUga2V5IHByZXNzZWRcbiAgICAgICAgICAgICAgICB2YXIga2V5ID0gZXZlbnQua2V5O1xuXG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBzdGF0ZSBvZiB0aGUgbW9kaWZpZXIga2V5c1xuICAgICAgICAgICAgICAgIC8vIHZhciBpc0N0cmxLZXkgPSBldmVudC5jdHJsS2V5IHx8IGV2ZW50Lm1ldGFLZXk7XG4gICAgICAgICAgICAgICAgLy8gdmFyIGlzQWx0S2V5ID0gZXZlbnQuYWx0S2V5O1xuICAgICAgICAgICAgICAgIHZhciBpc1NoaWZ0S2V5ID0gZXZlbnQuc2hpZnRLZXk7XG4gICAgICAgICAgICAgICAgdmFyIGlzQ3RybEtleSA9IGZhbHNlO1xuICAgICAgICAgICAgICAgIHZhciBpc0FsdEtleSA9IGZhbHNlO1xuXG4gICAgICAgICAgICAgICAgLy8gQ2hlY2sgaWYgYW55IGNvbWJpbmF0aW9uIG9mIG1vZGlmaWVyIGtleXMgYW5kIG5vcm1hbCBrZXlzIHdlcmUgcHJlc3NlZFxuICAgICAgICAgICAgICAgIC8vIGlmIChpc0N0cmxLZXkgfHwgaXNBbHRLZXkgfHwgaXNTaGlmdEtleSB8fCBrZXkgPT09ICdUYWInKSB7XG4gICAgICAgICAgICAgICAgLy8gaWYgKGtleSA9PT0gJ1RhYicgfHwgaXNTaGlmdEtleSAmJiBrZXkgPT09ICdUYWInKSB7XG4gICAgICAgICAgICAgICAgaWYgKGtleSA9PT0gJ1RhYicpIHtcbiAgICAgICAgICAgICAgICAgICAgZXZlbnQucHJldmVudERlZmF1bHQoKTsgLy8gUHJldmVudCB0aGUgZGVmYXVsdCBldmVudCBiZWhhdmlvclxuICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgIH0pO1xuXG5cbiAgICAgICAgICAgIGlmICh0aGlzLnRhcmdldCBpbnN0YW5jZW9mIEhUTUxTZWxlY3RFbGVtZW50KSB7XG4gICAgICAgICAgICAgICAgaWYgKHRoaXMudGFyZ2V0Lmhhc0F0dHJpYnV0ZSgnZGF0YS1jaG9pY2UnKSkge1xuICAgICAgICAgICAgICAgICAgICB0aGlzLnRhcmdldCA9IHRoaXMudGFyZ2V0LnBhcmVudEVsZW1lbnQucGFyZW50RWxlbWVudDtcbiAgICAgICAgICAgICAgICAgICAgY29uc3QgZHJvcGRvd24gPSB0aGlzLnRhcmdldC5xdWVyeVNlbGVjdG9yKCcuY2hvaWNlc19fbGlzdC5jaG9pY2VzX19saXN0LS1kcm9wZG93bicpO1xuICAgICAgICAgICAgICAgICAgICBkcm9wZG93bi5zdHlsZS56SW5kZXggPSAxMDA7XG4gICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICBpZiAodGhpcy50YXJnZXQudGFnTmFtZSA9PT0gJ1RSSVgtRURJVE9SJykge1xuICAgICAgICAgICAgICAgIHRoaXMudGltZW91dHNbJ3RyaXgnXSA9IHRoaXMudGFyZ2V0LmNsaWVudEhlaWdodDtcbiAgICAgICAgICAgICAgICB0aGlzLnRhcmdldCA9IHRoaXMudGFyZ2V0LnBhcmVudEVsZW1lbnQ7XG5cbiAgICAgICAgICAgICAgICBjb25zdCBvYnNlcnZlciA9IG5ldyBNdXRhdGlvbk9ic2VydmVyKChtdXRhdGlvbnNMaXN0LCBvYnNlcnZlcikgPT4ge1xuXG4gICAgICAgICAgICAgICAgICAgIG11dGF0aW9uc0xpc3QuZm9yRWFjaCgobXV0YXRpb24pID0+IHtcblxuICAgICAgICAgICAgICAgICAgICAgICAgaWYgKHRoaXMudGltZW91dHNbJ3RyaXgnXSkge1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNsZWFyVGltZW91dCh0aGlzLnRpbWVvdXRzWyd0cml4J10pO1xuICAgICAgICAgICAgICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0cml4J10gPSBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0cml4J10gPSBudWxsO1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMuaW5pdCgpO1xuICAgICAgICAgICAgICAgICAgICAgICAgfSwgNTAwKTtcbiAgICAgICAgICAgICAgICAgICAgfSk7XG4gICAgICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgICAgICBjb25zdCBjb25maWcgPSB7XG4gICAgICAgICAgICAgICAgICAgIGF0dHJpYnV0ZXM6IHRydWUsXG4gICAgICAgICAgICAgICAgICAgIGF0dHJpYnV0ZUZpbHRlcjogWydoZWlnaHQnXSxcbiAgICAgICAgICAgICAgICAgICAgY2hpbGRMaXN0OiB0cnVlLFxuICAgICAgICAgICAgICAgICAgICBzdWJ0cmVlOiB0cnVlLFxuICAgICAgICAgICAgICAgIH07XG5cbiAgICAgICAgICAgICAgICBvYnNlcnZlci5vYnNlcnZlKHRoaXMudGFyZ2V0LCBjb25maWcpO1xuXG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIGlmICh0aGlzLnRhcmdldCBpbnN0YW5jZW9mIEhUTUxUZXh0QXJlYUVsZW1lbnQgfHwgdGhpcy50KSB7XG4gICAgICAgICAgICAgICAgLy8gR2V0IHRoZSBpbml0aWFsIHNpemUgb2YgdGhlIHRleHRhcmVhXG4gICAgICAgICAgICAgICAgbGV0IGluaXRpYWxXaWR0aCA9IHRoaXMudGFyZ2V0Lm9mZnNldFdpZHRoO1xuICAgICAgICAgICAgICAgIGxldCBpbml0aWFsSGVpZ2h0ID0gdGhpcy50YXJnZXQub2Zmc2V0SGVpZ2h0O1xuXG4gICAgICAgICAgICAgICAgLy8gQ3JlYXRlIGEgTXV0YXRpb25PYnNlcnZlciB0byBtb25pdG9yIHNpemUgY2hhbmdlc1xuICAgICAgICAgICAgICAgIGNvbnN0IG9ic2VydmVyID0gbmV3IE11dGF0aW9uT2JzZXJ2ZXIoKCkgPT4ge1xuICAgICAgICAgICAgICAgICAgICBpZiAodGhpcy50YXJnZXQub2Zmc2V0V2lkdGggIT09IGluaXRpYWxXaWR0aCB8fCB0aGlzLnRhcmdldC5vZmZzZXRIZWlnaHQgIT09IGluaXRpYWxIZWlnaHQpIHtcbiAgICAgICAgICAgICAgICAgICAgICAgIGluaXRpYWxXaWR0aCA9IHRoaXMudGFyZ2V0Lm9mZnNldFdpZHRoO1xuICAgICAgICAgICAgICAgICAgICAgICAgaW5pdGlhbEhlaWdodCA9IHRoaXMudGFyZ2V0Lm9mZnNldEhlaWdodDtcblxuICAgICAgICAgICAgICAgICAgICAgICAgaWYgKHRoaXMudGltZW91dHNbJ3RleHRhcmVhJ10pIHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICBjbGVhclRpbWVvdXQodGhpcy50aW1lb3V0c1sndGV4dGFyZWEnXSk7XG4gICAgICAgICAgICAgICAgICAgICAgICB9XG5cbiAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMudGltZW91dHNbJ3RleHRhcmVhJ10gPSBzZXRUaW1lb3V0KCgpID0+IHtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnRpbWVvdXRzWyd0ZXh0YXJlYSddID0gbnVsbDtcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0aGlzLmluaXQoKTtcbiAgICAgICAgICAgICAgICAgICAgICAgIH0sIDEwMCk7XG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICB9KTtcblxuICAgICAgICAgICAgICAgIC8vIFN0YXJ0IG9ic2VydmluZyBjaGFuZ2VzIGluIHRoZSB0ZXh0YXJlYSBlbGVtZW50XG4gICAgICAgICAgICAgICAgb2JzZXJ2ZXIub2JzZXJ2ZSh0aGlzLnRhcmdldCwge2F0dHJpYnV0ZXM6IHRydWUsIGF0dHJpYnV0ZUZpbHRlcjogWydzdHlsZSddfSk7XG4gICAgICAgICAgICB9XG4gICAgICAgIH0sXG4gICAgICAgIC8vIFlvdSBjYW4gZGVmaW5lIGFueSBvdGhlciBBbHBpbmUuanMgZnVuY3Rpb25zIGhlcmUuXG5cbiAgICAgICAgaW5pdGlhbGl6ZURpYWxvZzogZnVuY3Rpb24gKGRpYWxvZyA9IG51bGwpIHtcbiAgICAgICAgICAgIGlmICghZGlhbG9nKSB7XG4gICAgICAgICAgICAgICAgZGlhbG9nID0gdGhpcy4kZWwucXVlcnlTZWxlY3RvcignW2RhdGEtZGlhbG9nXScpO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgZGlhbG9nUGF0aCA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCdbZGF0YS1kaWFsb2ctcGF0aF0nKTtcblxuICAgICAgICAgICAgY29uc3QgcmVjdCA9IHRoaXMuZWxlbWVudFJlY3QoKTtcbiAgICAgICAgICAgIC8vIGNvbnN0IGhlYWRlciA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCdbZGF0YS1kaWFsb2ctaGVhZGVyXScpO1xuICAgICAgICAgICAgY29uc3Qgc3Ryb2tlID0gZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJ1tkYXRhLWRpYWxvZy1zdHJva2VdJyk7XG5cbiAgICAgICAgICAgIHdpbmRvdy5zY3JvbGxUbyh7XG4gICAgICAgICAgICAgICAgdG9wOiByZWN0WzBdLnkgLSAod2luZG93LmlubmVySGVpZ2h0IC8gMyksXG4gICAgICAgICAgICAgICAgbGVmdDogcmVjdFswXS54LFxuICAgICAgICAgICAgICAgIGJlaGF2aW9yOiAnc21vb3RoJ1xuICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgIGNvbnN0IHdpZHRoID0gcmVjdFsxXS54IC0gcmVjdFswXS54O1xuICAgICAgICAgICAgY29uc3QgaGVpZ2h0ID0gcmVjdFsyXS55IC0gcmVjdFswXS55O1xuXG4gICAgICAgICAgICBjb25zdCB4ID0gcmVjdFswXS54O1xuICAgICAgICAgICAgY29uc3QgeSA9IHJlY3RbMF0ueTtcbiAgICAgICAgICAgIGRpYWxvZy5zdHlsZS53aWR0aCA9IGAke3dpZHRofXB4YDtcbiAgICAgICAgICAgIGRpYWxvZy5zdHlsZS50cmFuc2Zvcm0gPSBgdHJhbnNsYXRlKCR7eH1weCwgJHt5fXB4KWA7XG4gICAgICAgICAgICBzdHJva2Uuc3R5bGUuaGVpZ2h0ID0gYCR7aGVpZ2h0fXB4YDtcblxuICAgICAgICAgICAgZGlhbG9nUGF0aC5zZXRBdHRyaWJ1dGUoJ2QnLCB0aGlzLmVsZW1lbnRQYXRoKG51bGwsIHtyZWxhdGl2ZTogdHJ1ZSwgcG9zaXRpdmU6IHRydWV9KSlcbiAgICAgICAgfSxcblxuICAgICAgICBjbGlwUGF0aDogZnVuY3Rpb24gKGVsZW1lbnQgPSBudWxsLCBvcHRpb25zID0ge30pIHtcbiAgICAgICAgICAgIGVsZW1lbnQgPSBlbGVtZW50IHx8IHRoaXMudGFyZ2V0O1xuICAgICAgICAgICAgb3B0aW9ucyA9IHtcbiAgICAgICAgICAgICAgICByYWRpdXM6IDI0LFxuICAgICAgICAgICAgICAgIG1hcmdpbjogMTAsXG4gICAgICAgICAgICAgICAgb2Zmc2V0OiB7eDogMCwgeTogMH0sXG4gICAgICAgICAgICAgICAgcmVsYXRpdmU6IGZhbHNlLFxuICAgICAgICAgICAgICAgIC4uLm9wdGlvbnNcbiAgICAgICAgICAgIH1cbiAgICAgICAgICAgIHJldHVybiBgJHt0aGlzLndpbmRvd1BhdGgoKX0gJHt0aGlzLmVsZW1lbnRQYXRoKGVsZW1lbnQsIG9wdGlvbnMpfWAudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIHdpbmRvd1BhdGg6IGZ1bmN0aW9uICgpIHtcbiAgICAgICAgICAgIGNvbnN0IGRvY3VtZW50SGVpZ2h0ID0gTWF0aC5tYXgoXG4gICAgICAgICAgICAgICAgZG9jdW1lbnQuZG9jdW1lbnRFbGVtZW50LmNsaWVudEhlaWdodCxcbiAgICAgICAgICAgICAgICBkb2N1bWVudC5kb2N1bWVudEVsZW1lbnQuc2Nyb2xsSGVpZ2h0LFxuICAgICAgICAgICAgICAgIGRvY3VtZW50LmRvY3VtZW50RWxlbWVudC5vZmZzZXRIZWlnaHQsXG4gICAgICAgICAgICApO1xuXG4gICAgICAgICAgICAvLyBUT0RPOiBhZGQgb3B0aW9uIHRvIHNlbGVjdCBjbG9ja3dpc2UgL2NvdW50ZXIgY2xvY2t3aXNlXG4gICAgICAgICAgICAvL00gMCA4IEMgMCAwIDAgMCA4IDAgTCAzOCAwIEMgNDYgMCA0NiAwIDQ2IDggQyA0NiAxNiA0NiAxNiAzOCAxNiBMIDggMTYgQyAwIDE2IDAgMTYgMCA4XG4gICAgICAgICAgICBsZXQgcGF0aCA9ICdNIDAgMCAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAwICcgKyBkb2N1bWVudEhlaWdodCArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0wgJyArIHdpbmRvdy5pbm5lcldpZHRoICsgJyAnICsgZG9jdW1lbnRIZWlnaHQgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdMICcgKyB3aW5kb3cuaW5uZXJXaWR0aCArICcgMCAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAwIDAgJztcblxuICAgICAgICAgICAgcmV0dXJuIHBhdGgudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIGZpbmRFbGVtZW50OiBmdW5jdGlvbiAobmFtZSkge1xuICAgICAgICAgICAgcmV0dXJuIGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3Ioc2VsZWN0b3IucmVwbGFjZSgvXFwuL2csICdcXFxcJCYnKSlcbiAgICAgICAgICAgICAgICA/PyBkb2N1bWVudC5xdWVyeVNlbGVjdG9yKHNlbGVjdG9yKTtcbiAgICAgICAgfSxcblxuICAgICAgICBlbGVtZW50UGF0aDogZnVuY3Rpb24gKGVsZW1lbnQgPSBudWxsLCBvcHRpb25zID0ge30pIHtcbiAgICAgICAgICAgIGVsZW1lbnQgPSBlbGVtZW50IHx8IHRoaXMudGFyZ2V0O1xuICAgICAgICAgICAgb3B0aW9ucyA9IHtcbiAgICAgICAgICAgICAgICByYWRpdXM6IDI0LFxuICAgICAgICAgICAgICAgIG1hcmdpbjogMTAsXG4gICAgICAgICAgICAgICAgb2Zmc2V0OiB7eDogMCwgeTogMH0sXG4gICAgICAgICAgICAgICAgLi4ub3B0aW9uc1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgcmVjdCA9IHRoaXMuZWxlbWVudFJlY3QoZWxlbWVudCwge1xuICAgICAgICAgICAgICAgIHJlbGF0aXZlOiBmYWxzZSxcbiAgICAgICAgICAgICAgICAuLi5vcHRpb25zLFxuICAgICAgICAgICAgfSk7XG5cbiAgICAgICAgICAgIGxldCBwYXRoID0gJyc7XG4gICAgICAgICAgICBwYXRoICs9ICdNICcgKyByZWN0WzBdLnggKyAnICcgKyAocmVjdFswXS55ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnQyAnICsgcmVjdFswXS54ICsgJyAnICsgcmVjdFswXS55ICsgJyAnICsgcmVjdFswXS54ICsgJyAnICsgcmVjdFswXS55ICsgJyAnICsgKHJlY3RbMF0ueCArIG9wdGlvbnMucmFkaXVzKSArICcgJyArIHJlY3RbMF0ueSArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0wgJyArIChyZWN0WzFdLnggLSBvcHRpb25zLnJhZGl1cykgKyAnICcgKyByZWN0WzFdLnkgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdDICcgKyByZWN0WzFdLnggKyAnICcgKyByZWN0WzFdLnkgKyAnICcgKyByZWN0WzFdLnggKyAnICcgKyByZWN0WzFdLnkgKyAnICcgKyByZWN0WzFdLnggKyAnICcgKyAocmVjdFsxXS55ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAnICsgcmVjdFsyXS54ICsgJyAnICsgKHJlY3RbMl0ueSAtIG9wdGlvbnMucmFkaXVzKSArICcgJztcbiAgICAgICAgICAgIHBhdGggKz0gJ0MgJyArIHJlY3RbMl0ueCArICcgJyArIHJlY3RbMl0ueSArICcgJyArIHJlY3RbMl0ueCArICcgJyArIHJlY3RbMl0ueSArICcgJyArIChyZWN0WzJdLnggLSBvcHRpb25zLnJhZGl1cykgKyAnICcgKyByZWN0WzJdLnkgKyAnICc7XG4gICAgICAgICAgICBwYXRoICs9ICdMICcgKyAocmVjdFszXS54ICsgb3B0aW9ucy5yYWRpdXMpICsgJyAnICsgcmVjdFszXS55ICsgJyAnO1xuICAgICAgICAgICAgcGF0aCArPSAnQyAnICsgcmVjdFszXS54ICsgJyAnICsgcmVjdFszXS55ICsgJyAnICsgcmVjdFszXS54ICsgJyAnICsgcmVjdFszXS55ICsgJyAnICsgcmVjdFszXS54ICsgJyAnICsgKHJlY3RbM10ueSAtIG9wdGlvbnMucmFkaXVzKSArICcgJztcbiAgICAgICAgICAgIC8vIHBhdGggKz0gJ1onO1xuICAgICAgICAgICAgcGF0aCArPSAnTCAnICsgcmVjdFswXS54ICsgJyAnICsgKHJlY3RbMF0ueSArIG9wdGlvbnMucmFkaXVzKSArICcgJztcblxuICAgICAgICAgICAgcmV0dXJuIHBhdGgudHJpbSgpO1xuICAgICAgICB9LFxuXG4gICAgICAgIGVsZW1lbnRSZWN0OiBmdW5jdGlvbiAoZWxlbWVudCA9IG51bGwsIG9wdGlvbnMgPSB7fSkge1xuXG4gICAgICAgICAgICBlbGVtZW50ID0gZWxlbWVudCB8fCB0aGlzLnRhcmdldDtcbiAgICAgICAgICAgIGNvbnN0IGJvdW5kcyA9IGVsZW1lbnQuZ2V0Qm91bmRpbmdDbGllbnRSZWN0KCk7XG4gICAgICAgICAgICBvcHRpb25zID0ge1xuICAgICAgICAgICAgICAgIHJhZGl1czogMjQsXG4gICAgICAgICAgICAgICAgbWFyZ2luOiAxMCxcbiAgICAgICAgICAgICAgICBvZmZzZXQ6IHt4OiAwLCB5OiAwfSxcbiAgICAgICAgICAgICAgICByZWxhdGl2ZTogZmFsc2UsXG4gICAgICAgICAgICAgICAgLi4ub3B0aW9uc1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgY29uc3QgbGVmdCA9IG9wdGlvbnMucmVsYXRpdmUgPyAwIDogYm91bmRzLmxlZnQ7XG4gICAgICAgICAgICBjb25zdCB0b3AgPSBvcHRpb25zLnJlbGF0aXZlID8gMCA6IGVsZW1lbnQub2Zmc2V0VG9wO1xuXG4gICAgICAgICAgICBsZXQgcmVzdWx0ID0gW1xuICAgICAgICAgICAgICAgIHtcbiAgICAgICAgICAgICAgICAgICAgeDogbGVmdCAtIG9wdGlvbnMubWFyZ2luICsgb3B0aW9ucy5vZmZzZXQueCxcbiAgICAgICAgICAgICAgICAgICAgeTogdG9wIC0gb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfSxcbiAgICAgICAgICAgICAgICB7XG4gICAgICAgICAgICAgICAgICAgIHg6IGxlZnQgKyBlbGVtZW50LmNsaWVudFdpZHRoICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC54LFxuICAgICAgICAgICAgICAgICAgICB5OiB0b3AgLSBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LnlcbiAgICAgICAgICAgICAgICB9LFxuICAgICAgICAgICAgICAgIHtcbiAgICAgICAgICAgICAgICAgICAgeDogbGVmdCArIGVsZW1lbnQuY2xpZW50V2lkdGggKyBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LngsXG4gICAgICAgICAgICAgICAgICAgIHk6IHRvcCArIGVsZW1lbnQuY2xpZW50SGVpZ2h0ICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfSxcbiAgICAgICAgICAgICAgICB7XG4gICAgICAgICAgICAgICAgICAgIHg6IGxlZnQgLSBvcHRpb25zLm1hcmdpbiArIG9wdGlvbnMub2Zmc2V0LngsXG4gICAgICAgICAgICAgICAgICAgIHk6IHRvcCArIGVsZW1lbnQuY2xpZW50SGVpZ2h0ICsgb3B0aW9ucy5tYXJnaW4gKyBvcHRpb25zLm9mZnNldC55XG4gICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgXTtcblxuICAgICAgICAgICAgaWYgKG9wdGlvbnMucG9zaXRpdmUpIHtcbiAgICAgICAgICAgICAgICBsZXQgbWluWCA9IDA7XG4gICAgICAgICAgICAgICAgbGV0IG1pblkgPSAwO1xuXG4gICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCByZXN1bHQubGVuZ3RoOyBpKyspIHtcbiAgICAgICAgICAgICAgICAgICAgaWYgKHJlc3VsdFtpXS54IDwgbWluWCkge1xuICAgICAgICAgICAgICAgICAgICAgICAgbWluWCA9IHJlc3VsdFtpXS54O1xuICAgICAgICAgICAgICAgICAgICB9XG5cbiAgICAgICAgICAgICAgICAgICAgaWYgKHJlc3VsdFtpXS55IDwgbWluWSkge1xuICAgICAgICAgICAgICAgICAgICAgICAgbWluWSA9IHJlc3VsdFtpXS55O1xuICAgICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICAgICAgZm9yIChsZXQgaSA9IDA7IGkgPCByZXN1bHQubGVuZ3RoOyBpKyspIHtcbiAgICAgICAgICAgICAgICAgICAgcmVzdWx0W2ldLnggLT0gbWluWDtcbiAgICAgICAgICAgICAgICAgICAgcmVzdWx0W2ldLnkgLT0gbWluWTtcbiAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIHJldHVybiByZXN1bHQ7XG4gICAgICAgIH1cbiAgICB9XG59Il0sCiAgIm1hcHBpbmdzIjogIjtBQUFlLFNBQVIsY0FBK0I7QUFBQSxFQUNJO0FBQUEsRUFDQTtBQUFBLEVBQ0E7QUFBQSxFQUNBO0FBQ0osR0FBRztBQUNyQyxTQUFPO0FBQUEsSUFDSCxRQUFRO0FBQUEsSUFFUixPQUFPLFNBQVUsSUFBSTtBQUNqQixhQUFPLElBQUksUUFBUSxhQUFXLFdBQVcsU0FBUyxFQUFFLENBQUM7QUFBQSxJQUN6RDtBQUFBLElBRUEsTUFBTSxpQkFBa0I7QUFDcEIsV0FBSyxTQUFTLEtBQUssWUFBWSxHQUFHO0FBRWxDLFVBQUksQ0FBQyxLQUFLLFFBQVE7QUFDZCxnQkFBUSxNQUFNLGdDQUFnQyxHQUFHO0FBQ2pEO0FBQUEsTUFDSjtBQUlBLGVBQVMsZ0JBQWdCLGlCQUFpQixPQUFPLEVBQzVDLFFBQVEsQ0FBQyxZQUFZLFFBQVEsS0FBSyxDQUFDO0FBQ3hDLFVBQUksS0FBSyxRQUFRO0FBQ2IsYUFBSyxPQUFPLE1BQU07QUFBQSxNQUN0QjtBQUVBLFdBQUssVUFBVTtBQUVmLFlBQU0sU0FBUyxLQUFLLElBQUksY0FBYyxlQUFlO0FBQ3JELFlBQU0sV0FBVyxLQUFLLElBQUksY0FBYyxrQkFBa0I7QUFFMUQsVUFBSSxzQkFBc0I7QUFDdEIsYUFBSyxPQUFPLGlCQUFpQixTQUFTLENBQUMsVUFBVTtBQUM3QyxnQkFBTSxlQUFlO0FBQ3JCLGVBQUssTUFBTSxLQUFLLG9CQUFvQjtBQUVwQyxlQUFLLE9BQU8sS0FBSztBQUNqQixnQkFBTSxjQUFjLEtBQUssT0FBTyxpQkFBaUIsUUFBUTtBQUV6RCxtQkFBUyxJQUFJLEdBQUcsSUFBSSxZQUFZLFFBQVEsS0FBSztBQUN6QyxrQkFBTSxhQUFhLFlBQVksQ0FBQztBQUNoQyx1QkFBVyxLQUFLO0FBQUEsVUFDcEI7QUFBQSxRQUNKLENBQUM7QUFBQSxNQUNMO0FBRUEsV0FBSyxpQkFBaUI7QUFFdEIsV0FBSyxVQUFVLE1BQU07QUFDakIsaUJBQVMsYUFBYSxLQUFLLEtBQUssU0FBUyxDQUFDO0FBQzFDLGFBQUssVUFBVSxrQkFBa0I7QUFBQSxNQUNyQyxDQUFDO0FBRUQsZUFBUyxhQUFhLEtBQUssS0FBSyxTQUFTLENBQUM7QUFBQSxJQUM5QztBQUFBLElBRUEsVUFBVSxDQUFDO0FBQUEsSUFFWCxXQUFXLFdBQVk7QUFDbkIsZUFBUyxpQkFBaUIsV0FBVyxTQUFVLE9BQU87QUFFbEQsWUFBSUEsT0FBTSxNQUFNO0FBS2hCLFlBQUksYUFBYSxNQUFNO0FBQ3ZCLFlBQUksWUFBWTtBQUNoQixZQUFJLFdBQVc7QUFLZixZQUFJQSxTQUFRLE9BQU87QUFDZixnQkFBTSxlQUFlO0FBQUEsUUFDekI7QUFBQSxNQUNKLENBQUM7QUFHRCxVQUFJLEtBQUssa0JBQWtCLG1CQUFtQjtBQUMxQyxZQUFJLEtBQUssT0FBTyxhQUFhLGFBQWEsR0FBRztBQUN6QyxlQUFLLFNBQVMsS0FBSyxPQUFPLGNBQWM7QUFDeEMsZ0JBQU0sV0FBVyxLQUFLLE9BQU8sY0FBYyx3Q0FBd0M7QUFDbkYsbUJBQVMsTUFBTSxTQUFTO0FBQUEsUUFDNUI7QUFBQSxNQUNKO0FBRUEsVUFBSSxLQUFLLE9BQU8sWUFBWSxlQUFlO0FBQ3ZDLGFBQUssU0FBUyxNQUFNLElBQUksS0FBSyxPQUFPO0FBQ3BDLGFBQUssU0FBUyxLQUFLLE9BQU87QUFFMUIsY0FBTSxXQUFXLElBQUksaUJBQWlCLENBQUMsZUFBZUMsY0FBYTtBQUUvRCx3QkFBYyxRQUFRLENBQUMsYUFBYTtBQUVoQyxnQkFBSSxLQUFLLFNBQVMsTUFBTSxHQUFHO0FBQ3ZCLDJCQUFhLEtBQUssU0FBUyxNQUFNLENBQUM7QUFBQSxZQUN0QztBQUVBLGlCQUFLLFNBQVMsTUFBTSxJQUFJLFdBQVcsTUFBTTtBQUNyQyxtQkFBSyxTQUFTLE1BQU0sSUFBSTtBQUN4QixtQkFBSyxLQUFLO0FBQUEsWUFDZCxHQUFHLEdBQUc7QUFBQSxVQUNWLENBQUM7QUFBQSxRQUNMLENBQUM7QUFFRCxjQUFNLFNBQVM7QUFBQSxVQUNYLFlBQVk7QUFBQSxVQUNaLGlCQUFpQixDQUFDLFFBQVE7QUFBQSxVQUMxQixXQUFXO0FBQUEsVUFDWCxTQUFTO0FBQUEsUUFDYjtBQUVBLGlCQUFTLFFBQVEsS0FBSyxRQUFRLE1BQU07QUFBQSxNQUV4QztBQUVBLFVBQUksS0FBSyxrQkFBa0IsdUJBQXVCLEtBQUssR0FBRztBQUV0RCxZQUFJLGVBQWUsS0FBSyxPQUFPO0FBQy9CLFlBQUksZ0JBQWdCLEtBQUssT0FBTztBQUdoQyxjQUFNLFdBQVcsSUFBSSxpQkFBaUIsTUFBTTtBQUN4QyxjQUFJLEtBQUssT0FBTyxnQkFBZ0IsZ0JBQWdCLEtBQUssT0FBTyxpQkFBaUIsZUFBZTtBQUN4RiwyQkFBZSxLQUFLLE9BQU87QUFDM0IsNEJBQWdCLEtBQUssT0FBTztBQUU1QixnQkFBSSxLQUFLLFNBQVMsVUFBVSxHQUFHO0FBQzNCLDJCQUFhLEtBQUssU0FBUyxVQUFVLENBQUM7QUFBQSxZQUMxQztBQUVBLGlCQUFLLFNBQVMsVUFBVSxJQUFJLFdBQVcsTUFBTTtBQUN6QyxtQkFBSyxTQUFTLFVBQVUsSUFBSTtBQUM1QixtQkFBSyxLQUFLO0FBQUEsWUFDZCxHQUFHLEdBQUc7QUFBQSxVQUNWO0FBQUEsUUFDSixDQUFDO0FBR0QsaUJBQVMsUUFBUSxLQUFLLFFBQVEsRUFBQyxZQUFZLE1BQU0saUJBQWlCLENBQUMsT0FBTyxFQUFDLENBQUM7QUFBQSxNQUNoRjtBQUFBLElBQ0o7QUFBQTtBQUFBLElBR0Esa0JBQWtCLFNBQVUsU0FBUyxNQUFNO0FBQ3ZDLFVBQUksQ0FBQyxRQUFRO0FBQ1QsaUJBQVMsS0FBSyxJQUFJLGNBQWMsZUFBZTtBQUFBLE1BQ25EO0FBQ0EsWUFBTSxhQUFhLE9BQU8sY0FBYyxvQkFBb0I7QUFFNUQsWUFBTSxPQUFPLEtBQUssWUFBWTtBQUU5QixZQUFNLFNBQVMsT0FBTyxjQUFjLHNCQUFzQjtBQUUxRCxhQUFPLFNBQVM7QUFBQSxRQUNaLEtBQUssS0FBSyxDQUFDLEVBQUUsSUFBSyxPQUFPLGNBQWM7QUFBQSxRQUN2QyxNQUFNLEtBQUssQ0FBQyxFQUFFO0FBQUEsUUFDZCxVQUFVO0FBQUEsTUFDZCxDQUFDO0FBRUQsWUFBTSxRQUFRLEtBQUssQ0FBQyxFQUFFLElBQUksS0FBSyxDQUFDLEVBQUU7QUFDbEMsWUFBTSxTQUFTLEtBQUssQ0FBQyxFQUFFLElBQUksS0FBSyxDQUFDLEVBQUU7QUFFbkMsWUFBTSxJQUFJLEtBQUssQ0FBQyxFQUFFO0FBQ2xCLFlBQU0sSUFBSSxLQUFLLENBQUMsRUFBRTtBQUNsQixhQUFPLE1BQU0sUUFBUSxHQUFHLEtBQUs7QUFDN0IsYUFBTyxNQUFNLFlBQVksYUFBYSxDQUFDLE9BQU8sQ0FBQztBQUMvQyxhQUFPLE1BQU0sU0FBUyxHQUFHLE1BQU07QUFFL0IsaUJBQVcsYUFBYSxLQUFLLEtBQUssWUFBWSxNQUFNLEVBQUMsVUFBVSxNQUFNLFVBQVUsS0FBSSxDQUFDLENBQUM7QUFBQSxJQUN6RjtBQUFBLElBRUEsVUFBVSxTQUFVLFVBQVUsTUFBTSxVQUFVLENBQUMsR0FBRztBQUM5QyxnQkFBVSxXQUFXLEtBQUs7QUFDMUIsZ0JBQVU7QUFBQSxRQUNOLFFBQVE7QUFBQSxRQUNSLFFBQVE7QUFBQSxRQUNSLFFBQVEsRUFBQyxHQUFHLEdBQUcsR0FBRyxFQUFDO0FBQUEsUUFDbkIsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1A7QUFDQSxhQUFPLEdBQUcsS0FBSyxXQUFXLENBQUMsSUFBSSxLQUFLLFlBQVksU0FBUyxPQUFPLENBQUMsR0FBRyxLQUFLO0FBQUEsSUFDN0U7QUFBQSxJQUVBLFlBQVksV0FBWTtBQUNwQixZQUFNLGlCQUFpQixLQUFLO0FBQUEsUUFDeEIsU0FBUyxnQkFBZ0I7QUFBQSxRQUN6QixTQUFTLGdCQUFnQjtBQUFBLFFBQ3pCLFNBQVMsZ0JBQWdCO0FBQUEsTUFDN0I7QUFJQSxVQUFJLE9BQU87QUFDWCxjQUFRLFNBQVMsaUJBQWlCO0FBQ2xDLGNBQVEsT0FBTyxPQUFPLGFBQWEsTUFBTSxpQkFBaUI7QUFDMUQsY0FBUSxPQUFPLE9BQU8sYUFBYTtBQUNuQyxjQUFRO0FBRVIsYUFBTyxLQUFLLEtBQUs7QUFBQSxJQUNyQjtBQUFBLElBRUEsYUFBYSxTQUFVLE1BQU07QUFDekIsYUFBTyxTQUFTLGNBQWMsU0FBUyxRQUFRLE9BQU8sTUFBTSxDQUFDLEtBQ3RELFNBQVMsY0FBYyxRQUFRO0FBQUEsSUFDMUM7QUFBQSxJQUVBLGFBQWEsU0FBVSxVQUFVLE1BQU0sVUFBVSxDQUFDLEdBQUc7QUFDakQsZ0JBQVUsV0FBVyxLQUFLO0FBQzFCLGdCQUFVO0FBQUEsUUFDTixRQUFRO0FBQUEsUUFDUixRQUFRO0FBQUEsUUFDUixRQUFRLEVBQUMsR0FBRyxHQUFHLEdBQUcsRUFBQztBQUFBLFFBQ25CLEdBQUc7QUFBQSxNQUNQO0FBQ0EsWUFBTSxPQUFPLEtBQUssWUFBWSxTQUFTO0FBQUEsUUFDbkMsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1AsQ0FBQztBQUVELFVBQUksT0FBTztBQUNYLGNBQVEsT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVU7QUFDaEUsY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUk7QUFDeEksY0FBUSxRQUFRLEtBQUssQ0FBQyxFQUFFLElBQUksUUFBUSxVQUFVLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSTtBQUNoRSxjQUFRLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVTtBQUN4SSxjQUFRLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksUUFBUSxVQUFVO0FBQ2hFLGNBQVEsT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVUsTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJO0FBQ3hJLGNBQVEsUUFBUSxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUk7QUFDaEUsY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE1BQU0sS0FBSyxDQUFDLEVBQUUsSUFBSSxNQUFNLEtBQUssQ0FBQyxFQUFFLElBQUksTUFBTSxLQUFLLENBQUMsRUFBRSxJQUFJLE9BQU8sS0FBSyxDQUFDLEVBQUUsSUFBSSxRQUFRLFVBQVU7QUFFeEksY0FBUSxPQUFPLEtBQUssQ0FBQyxFQUFFLElBQUksT0FBTyxLQUFLLENBQUMsRUFBRSxJQUFJLFFBQVEsVUFBVTtBQUVoRSxhQUFPLEtBQUssS0FBSztBQUFBLElBQ3JCO0FBQUEsSUFFQSxhQUFhLFNBQVUsVUFBVSxNQUFNLFVBQVUsQ0FBQyxHQUFHO0FBRWpELGdCQUFVLFdBQVcsS0FBSztBQUMxQixZQUFNLFNBQVMsUUFBUSxzQkFBc0I7QUFDN0MsZ0JBQVU7QUFBQSxRQUNOLFFBQVE7QUFBQSxRQUNSLFFBQVE7QUFBQSxRQUNSLFFBQVEsRUFBQyxHQUFHLEdBQUcsR0FBRyxFQUFDO0FBQUEsUUFDbkIsVUFBVTtBQUFBLFFBQ1YsR0FBRztBQUFBLE1BQ1A7QUFDQSxZQUFNLE9BQU8sUUFBUSxXQUFXLElBQUksT0FBTztBQUMzQyxZQUFNLE1BQU0sUUFBUSxXQUFXLElBQUksUUFBUTtBQUUzQyxVQUFJLFNBQVM7QUFBQSxRQUNUO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFVBQzFDLEdBQUcsTUFBTSxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsUUFDN0M7QUFBQSxRQUNBO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxjQUFjLFFBQVEsU0FBUyxRQUFRLE9BQU87QUFBQSxVQUNoRSxHQUFHLE1BQU0sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFFBQzdDO0FBQUEsUUFDQTtBQUFBLFVBQ0ksR0FBRyxPQUFPLFFBQVEsY0FBYyxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsVUFDaEUsR0FBRyxNQUFNLFFBQVEsZUFBZSxRQUFRLFNBQVMsUUFBUSxPQUFPO0FBQUEsUUFDcEU7QUFBQSxRQUNBO0FBQUEsVUFDSSxHQUFHLE9BQU8sUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFVBQzFDLEdBQUcsTUFBTSxRQUFRLGVBQWUsUUFBUSxTQUFTLFFBQVEsT0FBTztBQUFBLFFBQ3BFO0FBQUEsTUFDSjtBQUVBLFVBQUksUUFBUSxVQUFVO0FBQ2xCLFlBQUksT0FBTztBQUNYLFlBQUksT0FBTztBQUVYLGlCQUFTLElBQUksR0FBRyxJQUFJLE9BQU8sUUFBUSxLQUFLO0FBQ3BDLGNBQUksT0FBTyxDQUFDLEVBQUUsSUFBSSxNQUFNO0FBQ3BCLG1CQUFPLE9BQU8sQ0FBQyxFQUFFO0FBQUEsVUFDckI7QUFFQSxjQUFJLE9BQU8sQ0FBQyxFQUFFLElBQUksTUFBTTtBQUNwQixtQkFBTyxPQUFPLENBQUMsRUFBRTtBQUFBLFVBQ3JCO0FBQUEsUUFDSjtBQUVBLGlCQUFTLElBQUksR0FBRyxJQUFJLE9BQU8sUUFBUSxLQUFLO0FBQ3BDLGlCQUFPLENBQUMsRUFBRSxLQUFLO0FBQ2YsaUJBQU8sQ0FBQyxFQUFFLEtBQUs7QUFBQSxRQUNuQjtBQUFBLE1BQ0o7QUFFQSxhQUFPO0FBQUEsSUFDWDtBQUFBLEVBQ0o7QUFDSjsiLAogICJuYW1lcyI6IFsia2V5IiwgIm9ic2VydmVyIl0KfQo=

--- a/public/js/guava/tutorials/components/step.js
+++ b/public/js/guava/tutorials/components/step.js
@@ -164,8 +164,9 @@ function stepComponent ({
     },
     findElement: function (name) {
       return (
-        document.querySelector(selector.replace(/\\/g, '\\\\').replace(/\./g, '\\$&')) ??
-                document.querySelector(selector)
+        document.querySelector(
+          selector.replace(/\\/g, '\\\\').replace(/\./g, '\\$&')
+        ) ?? document.querySelector(selector)
       )
     },
     elementPath: function (element = null, options = {}) {

--- a/public/js/guava/tutorials/components/step.js
+++ b/public/js/guava/tutorials/components/step.js
@@ -164,7 +164,7 @@ function stepComponent ({
     },
     findElement: function (name) {
       return (
-        document.querySelector(selector.replace(/\./g, '\\$&')) ??
+        document.querySelector(selector.replace(/\\/g, '\\\\').replace(/\./g, '\\$&')) ??
                 document.querySelector(selector)
       )
     },

--- a/resources/views/components/filament-fabricator/page-blocks/custom-html.blade.php
+++ b/resources/views/components/filament-fabricator/page-blocks/custom-html.blade.php
@@ -1,0 +1,13 @@
+@aware(['page','html' => '', 'use_container' => false, 'background' => 'none', 'padding' => 'py-0'])
+
+@if (! empty($html))
+    <section class="{{ $background !== 'none' ? $background : '' }} {{ $padding }}">
+        @if ($use_container)
+            <div class="container">
+                {!! $html !!}
+            </div>
+        @else
+            {!! $html !!}
+        @endif
+    </section>
+@endif

--- a/resources/views/components/filament-fabricator/page-blocks/markdown.blade.php
+++ b/resources/views/components/filament-fabricator/page-blocks/markdown.blade.php
@@ -1,0 +1,18 @@
+@aware(['page','markdown', 'customClass', 'showPreview' => false, 'editorHeight' => 'medium', 'allowUnsafe' => false])
+
+@php
+    $height = match ($editorHeight) {
+        'small' => 5,
+        'medium' => 10,
+        'large' => 20,
+        default => 10,
+    };
+@endphp
+
+<div class="{{ $customClass }}">
+    <div class="prose">
+        {!! $allowUnsafe
+            ? \Illuminate\Support\Str::markdown($markdown)
+            : \Illuminate\Support\Str::markdown(strip_tags($markdown)) !!}
+    </div>
+</div>

--- a/resources/views/components/filament-fabricator/page-blocks/markdown.blade.php
+++ b/resources/views/components/filament-fabricator/page-blocks/markdown.blade.php
@@ -1,13 +1,4 @@
-@aware(['page','markdown', 'customClass', 'showPreview' => false, 'editorHeight' => 'medium', 'allowUnsafe' => false])
-
-@php
-    $height = match ($editorHeight) {
-        'small' => 5,
-        'medium' => 10,
-        'large' => 20,
-        default => 10,
-    };
-@endphp
+@aware(['page','markdown', 'customClass', 'showPreview' => false, 'allowUnsafe' => false])
 
 <div class="{{ $customClass }}">
     <div class="prose">


### PR DESCRIPTION
Addresses #196

## Summary by Sourcery

Add HTML and Markdown page blocks to Filament Fabricator with configurable options and safety features

New Features:
- Introduced custom HTML block with configurable options like script allowance and container wrapping
- Added Markdown block with live preview and HTML safety controls
- Created a Blade directive to detect Filament admin routes

Enhancements:
- Integrated HTML Purifier for sanitizing HTML content
- Added flexible configuration options for page blocks
- Implemented safety toggles for potentially unsafe content