### PR TITLE
Bugfix/184 consolidate purchase verification logic to avoid duplication

### DIFF
--- a/app/Http/Controllers/ProductReviewController.php
+++ b/app/Http/Controllers/ProductReviewController.php
@@ -18,11 +18,7 @@ class ProductReviewController extends Controller
 
         $user = auth()->user();
 
-        $isVerified = $product->variants()
-            ->whereHas('orderItems.order', function ($q) use ($user) {
-                $q->where('user_id', $user->id);
-            })
-            ->exists();
+        $isVerified = ProductReview::verifyPurchase($user->id, $product->id);
 
         ProductReview::create([
             'product_id' => $product->id,

--- a/app/Models/ProductReview.php
+++ b/app/Models/ProductReview.php
@@ -20,23 +20,6 @@ class ProductReview extends Model
         'is_verified' => 'boolean',
     ];
 
-    public static function booted()
-    {
-        static::creating(function ($review) {
-            if (! $review->user_id) {
-                return;
-            }
-
-            $review->is_verified = OrderItem::whereHas(
-                'order',
-                fn ($q) => $q->where('user_id', $review->user_id)
-            )->whereHas(
-                'variant',
-                fn ($q) => $q->where('product_id', $review->product_id)
-            )->exists();
-        });
-    }
-
     public function product(): BelongsTo
     {
         return $this->belongsTo(Product::class);
@@ -50,5 +33,16 @@ class ProductReview extends Model
     public function canReview(): bool
     {
         return Helpers::userHasPurchasedProduct($this->user_id, $this->product_id);
+    }
+
+    public function verifyPurchase($user_id, $product_id): bool
+    {
+        return OrderItem::whereHas(
+            'order',
+            static fn ($q) => $q->where('user_id', $user_id)
+        )->whereHas(
+            'variant',
+            fn ($q) => $q->where('product_id', $product_id)
+        )->exists();
     }
 }


### PR DESCRIPTION
addresses #184

## Summary by Sourcery

Consolidate purchase verification logic for product reviews into a reusable method

Bug Fixes:
- Removed duplicated purchase verification logic across different parts of the application

Enhancements:
- Introduced a centralized method `verifyPurchase` in the ProductReview model to check if a user has purchased a product