### PR TITLE
Add created_at column to CommentResource table

### DIFF
--- a/app/Filament/Resources/CommentResource.php
+++ b/app/Filament/Resources/CommentResource.php
@@ -31,7 +31,7 @@ class CommentResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
-        $table = (new static::$model())->getTable();
+        $table = (new static::$model)->getTable();
 
         return parent::getEloquentQuery()
             // make sure to still pull in all comment columns
@@ -66,6 +66,11 @@ class CommentResource extends Resource
                 TextColumn::make('commentedOn')
                     ->label('On')
                     ->formatStateUsing(fn ($state, Comment $record) => class_basename($record->commented_on_type)." #{$record->commented_on_id}"),
+                TextColumn::make('created_at')
+                    ->label('Created')
+                    ->dateTime()          // renders a human-readable datetime
+                    ->since()             // “2 hours ago” style
+                    ->sortable(),
                 TextColumn::make('text')
                     ->label('Comment')
                     ->limit(50)

--- a/app/Filament/Resources/CommentResource.php
+++ b/app/Filament/Resources/CommentResource.php
@@ -31,6 +31,7 @@ class CommentResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
+        // Instantiate the class held by static::$model and get its table name.
         $table = (new static::$model)->getTable();
 
         return parent::getEloquentQuery()

--- a/app/Filament/Resources/CommentResource.php
+++ b/app/Filament/Resources/CommentResource.php
@@ -32,7 +32,7 @@ class CommentResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         // Instantiate the class held by static::$model and get its table name.
-        $table = (new static::$model)->getTable();
+        $table = (new static::$model())->getTable();
 
         return parent::getEloquentQuery()
             // make sure to still pull in all comment columns


### PR DESCRIPTION
The new column displays the comment's creation date in a human-readable format (e.g., "2 hours ago") and is sortable. This enhances the table's usability by providing additional context about when each comment was made.

## Summary by Sourcery

Add a human-readable, sortable creation date column to the CommentResource table and clean up model instantiation syntax in its query method

New Features:
- Add a sortable 'Created' column to CommentResource table that displays human-readable creation timestamps

Enhancements:
- Simplify model instantiation in getEloquentQuery by removing unnecessary parentheses