### PR TITLE
Add 'Contains URLs' filter to CommentResource

### DIFF
--- a/app/Filament/Resources/CommentResource.php
+++ b/app/Filament/Resources/CommentResource.php
@@ -34,7 +34,7 @@ class CommentResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         // Instantiate the class held by static::$model and get its table name.
-        $table = (new static::$model)->getTable();
+        $table = (new static::$model())->getTable();
 
         return parent::getEloquentQuery()
             // make sure to still pull in all comment columns


### PR DESCRIPTION
This new filter allows users to easily identify comments containing URLs, using regular expressions to match bare URLs and Markdown-style links in the text. It enhances the filtering capabilities of the CommentResource for better content moderation and review.

## Summary by Sourcery

Add a "Contains URLs" filter to CommentResource for identifying comments with URLs and streamline model instantiation in getEloquentQuery.

New Features:
- Add a "Contains URLs" filter to CommentResource to filter comments containing bare or Markdown-style URLs.

Enhancements:
- Simplify model instantiation in getEloquentQuery by removing unnecessary parentheses.