### PR TITLE
Bugfix/297 align pivot table name for permissiongroups relationship with migration

### DIFF
--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -2,16 +2,17 @@
 
 namespace App\Models;
 
+use App\Contracts\Role as RoleContract;
+use App\Traits\HasAdvancedPermissions;
 use App\Traits\IsPermissible;
 use Exception;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Spatie\Permission\Models\Role as SpatieRole;
-use App\Contracts\Role as RoleContract;
+use RuntimeException;
 use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Guard;
-use App\Traits\HasAdvancedPermissions;
 use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role as SpatieRole;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
 
 /**
@@ -20,43 +21,36 @@ use Spatie\Permission\Traits\RefreshesPermissionCache;
  * This class extends the SpatieRole and implements the Role contract.
  * It represents a role within the application, providing methods and properties
  * to manage and interact with roles.
- *
- * @package App\Models\Auth
  */
 class Role extends SpatieRole implements RoleContract
 {
-    use IsPermissible;
     use HasAdvancedPermissions;
+    use IsPermissible;
     use RefreshesPermissionCache;
 
     protected $fillable = ['name', 'protected'];
 
     protected $guarded = [];
 
-
     /**
      * Boot the model and its traits.
      *
      * This method is called when the model is initialized. It can be used to
      * register any event listeners or perform any setup required for the model.
-     *
-     * @return void
      */
     public static function boot(): void
     {
         parent::boot();
 
-        static::deleting(function ($role) {
+        static::deleting(static function ($role) {
             if ($role->protected) {
-                throw new Exception("The {$role->name} role cannot be deleted for security reasons.");
+                throw new RuntimeException("The {$role->name} role cannot be deleted for security reasons.");
             }
         });
     }
 
     /**
      * Create a new role instance.
-     *
-     * @param array $attributes
      */
     public function __construct(array $attributes = [])
     {
@@ -65,14 +59,12 @@ class Role extends SpatieRole implements RoleContract
         parent::__construct($attributes);
 
         $this->guarded[] = $this->primaryKey;
-        $this->table = config('permission.table_names.roles') ?: parent::getTable();
+        $this->table = config('permission.table_names.roles') ?: $this->getTable();
     }
 
     /**
      * Create a new role.
      *
-     * @param array $attributes
-     * @return RoleContract|Role
      *
      * @throws RoleAlreadyExists|Exception
      */
@@ -97,8 +89,8 @@ class Role extends SpatieRole implements RoleContract
         $createdRole = static::query()->create($attributes);
 
         // Ensure the created role is of the expected type
-        if (!$createdRole instanceof Role) {
-            throw new Exception("The created role is not of the expected type.");
+        if (! $createdRole instanceof self) {
+            throw new RuntimeException('The created role is not of the expected type.');
         }
 
         return $createdRole;
@@ -107,7 +99,6 @@ class Role extends SpatieRole implements RoleContract
     /**
      * A role may have multiple permissions.
      * This defines a many-to-many relationship with the Permission class.
-     * @return BelongsToMany
      */
     public function permissions(): BelongsToMany
     {
@@ -117,27 +108,24 @@ class Role extends SpatieRole implements RoleContract
     /**
      * A role may be assigned to various permission sets.
      * This defines a many-to-many relationship with the PermissionSet class.
-     * @return BelongsToMany
      */
     public function permissionSets(): BelongsToMany
     {
-        return $this->belongsToMany(PermissionSet::class, 'permission_set_role', 'role_id', 'permission_set_id');
+        return $this->belongsToMany(PermissionSet::class, 'role_has_permission_set', 'role_id', 'permission_set_id');
     }
 
     /**
      * A role may be assigned to various permission groups.
      * This defines a many-to-many relationship with the PermissionGroup class.
-     * @return BelongsToMany
      */
     public function permissionGroups(): BelongsToMany
     {
-        return $this->belongsToMany(PermissionGroup::class, 'permission_group_role', 'role_id', 'permission_group_id');
+        return $this->belongsToMany(PermissionGroup::class, 'role_has_permission_group', 'role_id', 'permission_group_id');
     }
 
     /**
      * A role belongs to some users of the model associated with its guard.
      * This defines a polymorphic many-to-many relationship with the User model.
-     * @return BelongsToMany
      */
     public function users(): BelongsToMany
     {
@@ -152,11 +140,6 @@ class Role extends SpatieRole implements RoleContract
 
     /**
      * Find a role by its name and guard name.
-     *
-     * @param string $name
-     * @param string|null $guardName
-     * @return RoleContract
-     *
      */
     public static function findByName(string $name, ?string $guardName = null): RoleContract
     {
@@ -164,7 +147,7 @@ class Role extends SpatieRole implements RoleContract
 
         $role = static::findByParam(['name' => $name, 'guard_name' => $guardName]);
 
-        if (!$role) {
+        if (! $role) {
             throw RoleDoesNotExist::named($name, $guardName);
         }
 
@@ -173,18 +156,14 @@ class Role extends SpatieRole implements RoleContract
 
     /**
      * Find a role by its id (and optionally guardName).
-     *
-     * @param int|string $id
-     * @param string|null $guardName
-     * @return RoleContract
      */
     public static function findById(int|string $id, ?string $guardName = null): RoleContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
-        $role = static::findByParam([(new static())->getKeyName() => $id, 'guard_name' => $guardName]);
+        $role = static::findByParam([(new static)->getKeyName() => $id, 'guard_name' => $guardName]);
 
-        if (!$role) {
+        if (! $role) {
             throw RoleDoesNotExist::withId($id, $guardName);
         }
 
@@ -194,9 +173,6 @@ class Role extends SpatieRole implements RoleContract
     /**
      * Find or create role by its name (and optionally guardName).
      *
-     * @param string $name
-     * @param string|null $guardName
-     * @return RoleContract
      * @throws Exception
      */
     public static function findOrCreate(string $name, ?string $guardName = null): RoleContract
@@ -205,12 +181,12 @@ class Role extends SpatieRole implements RoleContract
 
         $role = static::findByParam(['name' => $name, 'guard_name' => $guardName]);
 
-        if (!$role) {
+        if (! $role) {
             $createdRole = static::query()->create(['name' => $name, 'guard_name' => $guardName] + (app(PermissionRegistrar::class)->teams ? [app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId()] : []));
 
             // Ensure the created role is of the expected type
-            if (!$createdRole instanceof Role) {
-                throw new Exception("The created role is not of the expected type.");
+            if (! $createdRole instanceof self) {
+                throw new RuntimeException('The created role is not of the expected type.');
             }
 
             return $createdRole;
@@ -221,9 +197,6 @@ class Role extends SpatieRole implements RoleContract
 
     /**
      * Finds a role based on an array of parameters.
-     *
-     * @param array $params
-     * @return RoleContract|null
      */
     protected static function findByParam(array $params = []): ?RoleContract
     {
@@ -249,8 +222,7 @@ class Role extends SpatieRole implements RoleContract
     /**
      * See if the role has a permission directly.
      *
-     * @param Permission $permission
-     * @return bool
+     * @param  Permission  $permission
      */
     public function hasDirectPermission($permission): bool
     {
@@ -260,8 +232,7 @@ class Role extends SpatieRole implements RoleContract
     /**
      * See if the role has a permission through a permission set.
      *
-     * @param Permission $permission
-     * @return bool
+     * @param  Permission  $permission
      */
     public function hasPermissionThroughSet($permission): bool
     {
@@ -273,8 +244,7 @@ class Role extends SpatieRole implements RoleContract
     /**
      * See if the role has a permission through a permission group.
      *
-     * @param Permission $permission
-     * @return bool
+     * @param  Permission  $permission
      */
     public function hasPermissionThroughGroup($permission): bool
     {

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -161,7 +161,7 @@ class Role extends SpatieRole implements RoleContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
-        $role = static::findByParam([(new static)->getKeyName() => $id, 'guard_name' => $guardName]);
+        $role = static::findByParam([(new static())->getKeyName() => $id, 'guard_name' => $guardName]);
 
         if (! $role) {
             throw RoleDoesNotExist::withId($id, $guardName);


### PR DESCRIPTION
Addresses #297 and #298

## Summary by Sourcery

Align pivot table names with migration conventions, standardize exception handling, and streamline imports and code style in Role model and HasAdvancedPermissions trait

Bug Fixes:
- Use 'role_has_permission_set' and 'role_has_permission_group' pivot tables for Role relationships
- Adopt dynamic pivot table naming for permissionSets and permissionGroups in HasAdvancedPermissions trait

Enhancements:
- Replace generic Exception with RuntimeException for role errors
- Reorder imports, remove redundant docblocks, and standardize type hints and formatting