### PR TITLE
Refactor permission handling in HasAdvancedPermissions trait

### DIFF
--- a/app/Traits/HasAdvancedPermissions.php
+++ b/app/Traits/HasAdvancedPermissions.php
@@ -41,7 +41,7 @@ trait HasAdvancedPermissions
         }
 
         // If permission is muted for the user, deny access
-        if ($mutedPermissions->contains($permission instanceof Permission ? $permission->name : $permission)) {
+        if ($mutedPermissions->contains('name', $permission instanceof Permission ? $permission->name : $permission)) {
             // Log the muted permission
             logger()->debug('Permission is muted: '.($permission instanceof Permission ? $permission->name : $permission));
 

--- a/app/Traits/HasAdvancedPermissions.php
+++ b/app/Traits/HasAdvancedPermissions.php
@@ -40,16 +40,17 @@ trait HasAdvancedPermissions
             }
         }
 
+        $permissionName = $permission instanceof Permission ? $permission->name : $permission;
+
         // If permission is muted for the user, deny access
-        if ($mutedPermissions->contains('name', $permission instanceof Permission ? $permission->name : $permission)) {
+        if ($mutedPermissions->contains('name', $permissionName)) {
             // Log the muted permission
-            logger()->debug('Permission is muted: '.($permission instanceof Permission ? $permission->name : $permission));
+            logger()->debug('Permission is muted: '.$permissionName);
 
             return false;
         }
 
         // Check if user has permission directly
-        $permissionName = $permission instanceof Permission ? $permission->name : $permission;
         if ($this->permissions->contains('name', $permissionName)) {
             // Log the permission
             logger()->debug('Permission found: '.$permissionName.' (directly)');
@@ -97,13 +98,14 @@ trait HasAdvancedPermissions
      */
     public function hasPermissionViaRoles(int|string|Permission $permission): bool
     {
+        $permissionName = $permission instanceof Permission ? $permission->name : $permission;
+
         // Get the roles associated with the user
         $roles = $this->roles;
 
         // For each role, check for the permission, as well as under related PermissionSets and PermissionGroups, and ensure it is not muted in any of them
         foreach ($roles as $role) {
             // Check if the role has the permission directly
-            $permissionName = $permission instanceof Permission ? $permission->name : $permission;
             if ($role->permissions->contains('name', $permissionName)) {
                 return true;
             }
@@ -169,9 +171,8 @@ trait HasAdvancedPermissions
      */
     private function hasPermissionViaRolePermissionSets(mixed $role, mixed $permission): bool
     {
+        $normalizedPermission = is_string($permission) ? strtolower(trim($permission)) : strtolower($permission->name);
         foreach ($role->permissionSets as $permissionSet) {
-            $normalizedPermission = is_string($permission) ? strtolower(trim($permission)) : strtolower($permission->name);
-
             if ($permissionSet->permissions->contains('name', $normalizedPermission) && ! $permissionSet->permissions->where('name', $normalizedPermission)->first()->pivot->muted) {
                 return true;
             }

--- a/app/Traits/HasAdvancedPermissions.php
+++ b/app/Traits/HasAdvancedPermissions.php
@@ -41,17 +41,18 @@ trait HasAdvancedPermissions
         }
 
         // If permission is muted for the user, deny access
-        if ($mutedPermissions->contains($permission)) {
+        if ($mutedPermissions->contains($permission instanceof Permission ? $permission->name : $permission)) {
             // Log the muted permission
-            logger()->debug('Permission is muted: '.$permission);
+            logger()->debug('Permission is muted: '.($permission instanceof Permission ? $permission->name : $permission));
 
             return false;
         }
 
         // Check if user has permission directly
-        if ($this->permissions->contains('name', $permission)) {
+        $permissionName = $permission instanceof Permission ? $permission->name : $permission;
+        if ($this->permissions->contains('name', $permissionName)) {
             // Log the permission
-            logger()->debug('Permission found: '.$permission.' (directly)');
+            logger()->debug('Permission found: '.$permissionName.' (directly)');
 
             return true;
         }
@@ -102,7 +103,8 @@ trait HasAdvancedPermissions
         // For each role, check for the permission, as well as under related PermissionSets and PermissionGroups, and ensure it is not muted in any of them
         foreach ($roles as $role) {
             // Check if the role has the permission directly
-            if ($role->permissions->contains('name', $permission)) {
+            $permissionName = $permission instanceof Permission ? $permission->name : $permission;
+            if ($role->permissions->contains('name', $permissionName)) {
                 return true;
             }
 


### PR DESCRIPTION
Simplify and standardize permission checks by resolving `Permission` objects to their names. This ensures consistent logging and comparison logic, improving code clarity and maintainability.
Fixes #299

## Summary by Sourcery

Refactor permission handling to consistently resolve Permission objects to their names for reliable comparison and logging in the HasAdvancedPermissions trait.

Bug Fixes:
- Fix incorrect comparisons of Permission objects in muted, direct, and role-based permission checks to address issue #299

Enhancements:
- Standardize permission name resolution across muted, direct, and role-based checks
- Log permission names consistently for both denied and granted cases