### PR TITLE
Refactor permission check logic in PermissionSet model

### DIFF
--- a/app/Models/PermissionSet.php
+++ b/app/Models/PermissionSet.php
@@ -328,9 +328,18 @@ class PermissionSet extends BaseModel
         //check if the permission is assigned to the permission set
         if ($this->permissions()->contains($permission)) {
             //check if the permission is muted in the permission set
-            return $this->isMuted($permission);
+            $isMuted = $this->isMuted($permission);
+
+            if (!$isMuted) {
+                // If the permission is NOT muted, return as true
+                return true;
+            }
+
+            // The permission exists, but is marked as muted
+            return false;
         }
 
+        // The permission was not found or the object does not have the permission
         return false;
     }
 }


### PR DESCRIPTION
Updated the logic to clarify the handling of muted permissions and return early when a permission is active. This improves readability and ensures consistent behavior for permission checks.
Addresses issue #302

## Summary by Sourcery

Refactor the PermissionSet model’s hasPermissionTo method to improve handling of muted permissions and ensure early return for active permissions.

Bug Fixes:
- Ensure hasPermissionTo returns false for muted permissions instead of incorrectly granting access.

Enhancements:
- Streamline hasPermissionTo logic by extracting mute status and using early returns for active permissions.