### PR TITLE
Bugfix/301 fix improper use of eloquent relationship objects in getallpermissions method

### DIFF
--- a/app/Models/PermissionGroup.php
+++ b/app/Models/PermissionGroup.php
@@ -119,8 +119,8 @@ class PermissionGroup extends BaseModel
      */
     public function getAllPermissions(): ?array
     {
-        $permissions = $this->permissions();
-        $permissionSets = $this->permissionSets();
+        $permissions = $this->permissions()->get();
+        $permissionSets = $this->permissionSets()->get();
         $allPermissions = array();
 
         //go through each permission assigned to the permission set group directly, these will always be unmuted

--- a/app/Models/PermissionGroup.php
+++ b/app/Models/PermissionGroup.php
@@ -119,18 +119,18 @@ class PermissionGroup extends BaseModel
      */
     public function getAllPermissions(): ?array
     {
-        $permissions = $this->permissions()->get();
-        $permissionSets = $this->permissionSets()->get();
+        $permissions = $this->permissions()->get()->all();
+        $permissionSets = $this->permissionSets()->get()->all();
         $allPermissions = array();
 
         //go through each permission assigned to the permission set group directly, these will always be unmuted
-        foreach ($permissions as $permission) {
+        foreach (collect($permissions) as $permission) {
             $allPermissions[$permission->name] = false;
         }
 
         //go through each permission set assigned to the permission set group, and get the permissions from each set. keep permissions unique, and if a permission is muted in the set, mark it as muted.
-        foreach ($permissionSets as $permissionSet) {
-            foreach ($permissionSet->permissions as $permission) {
+        foreach (collect($permissionSets) as $permissionSet) {
+            foreach (collect($permissionSet->permissions) as $permission) {
                 //if the permission is already in the array, check if it is muted in the set, and if it is, mark it as muted if it is not already
                 if (array_key_exists($permission->name, $allPermissions)) {
                     if ($permissionSet->isMuted($permission)) {

--- a/app/Models/PermissionGroup.php
+++ b/app/Models/PermissionGroup.php
@@ -119,8 +119,8 @@ class PermissionGroup extends BaseModel
      */
     public function getAllPermissions(): ?array
     {
-        $permissions = $this->permissions()->get()->all();
-        $permissionSets = $this->permissionSets()->get()->all();
+        $permissions = $this->permissions()->get();
+        $permissionSets = $this->permissionSets()->get();
         $allPermissions = array();
 
         //go through each permission assigned to the permission set group directly, these will always be unmuted


### PR DESCRIPTION
Addresses #301

## Summary by Sourcery

Fix the getAllPermissions method to correctly fetch and iterate over permissions and permission sets as arrays

Bug Fixes:
- Retrieve permissions and permission sets using get()->all() before processing to avoid directly iterating over relationship objects
- Wrap permission and permission set loops with collect() to ensure proper iteration of array data