### PR TITLE
Add unique index to `permission_sets` table

### DIFF
--- a/database/migrations/2025_06_03_170526_add_unique_index_to_permissions_tables.php
+++ b/database/migrations/2025_06_03_170526_add_unique_index_to_permissions_tables.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */


### PR DESCRIPTION
This migration enforces uniqueness on the `name` and `guard_name` columns in the `permission_sets` table. It ensures data integrity by preventing duplicate entries for these fields.

## Summary by Sourcery

Add a migration to enforce uniqueness on the name and guard_name columns in the permission_sets table by adding a composite unique index with a corresponding rollback to drop it.

Enhancements:
- Add composite unique index on name and guard_name in permission_sets table
- Implement down migration to drop the composite unique index