### PR TITLE
Refactor PermissionRegistrar into services

### DIFF
--- a/app/Services/Permissions/PermissionCacheService.php
+++ b/app/Services/Permissions/PermissionCacheService.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Services\Permissions;
+
+use DateInterval;
+use Illuminate\Cache\CacheManager;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Database\Eloquent\Model;
+
+use function array_key_exists;
+
+/**
+ * Handle caching logic for permissions.
+ */
+class PermissionCacheService
+{
+    protected Repository $cache;
+
+    protected CacheManager $cacheManager;
+
+    /** @var DateInterval|int */
+    public $cacheExpirationTime;
+
+    public string $cacheKey;
+
+    public bool $teams;
+
+    public string $teamsKey;
+
+    public string $pivotRole;
+
+    public string $pivotPermission;
+
+    public string $pivotPermissionSet;
+
+    public string $pivotPermissionSetGroup;
+
+    protected string|int|null $teamId = null;
+
+    private array $wildcardPermissionsIndex = [];
+
+    public function __construct(CacheManager $cacheManager)
+    {
+        $this->cacheManager = $cacheManager;
+        $this->initialize();
+    }
+
+    public function initialize(): void
+    {
+        $this->cacheExpirationTime = config('permission.cache.expiration_time') ?: DateInterval::createFromDateString('24 hours');
+        $this->teams = config('permission.teams', false);
+        $this->teamsKey = config('permission.column_names.team_foreign_key', 'team_id');
+        $this->cacheKey = config('permission.cache.key');
+        $this->pivotRole = config('permission.column_names.role_pivot_key') ?: 'role_id';
+        $this->pivotPermission = config('permission.column_names.permission_pivot_key') ?: 'permission_id';
+        $this->pivotPermissionSet = config('permission.column_names.permission_set_pivot_key') ?: 'set_id';
+        $this->pivotPermissionSetGroup = config('permission.column_names.permission_set_group_pivot_key') ?: 'group_id';
+        $this->cache = $this->getCacheStoreFromConfig();
+    }
+
+    protected function getCacheStoreFromConfig(): Repository
+    {
+        $cacheDriver = config('permission.cache.store', 'default');
+
+        if ($cacheDriver === 'default') {
+            return $this->cacheManager->store();
+        }
+
+        if (! array_key_exists($cacheDriver, config('cache.stores'))) {
+            $cacheDriver = 'array';
+        }
+
+        return $this->cacheManager->store($cacheDriver);
+    }
+
+    public function setTeamId(int|string|Model|null $id): void
+    {
+        if ($id instanceof Model) {
+            $id = $id->getKey();
+        }
+        $this->teamId = $id;
+    }
+
+    public function getTeamId(): int|string|null
+    {
+        return $this->teamId;
+    }
+
+    public function forgetCachedPermissions(): bool
+    {
+        $this->wildcardPermissionsIndex = [];
+
+        return $this->cache->forget($this->cacheKey);
+    }
+
+    public function forgetWildcardPermissionIndex(?Model $record = null): void
+    {
+        if ($record) {
+            unset($this->wildcardPermissionsIndex[get_class($record)][$record->getKey()]);
+
+            return;
+        }
+
+        $this->wildcardPermissionsIndex = [];
+    }
+
+    public function getWildcardPermissionIndex(Model $record): array
+    {
+        if (isset($this->wildcardPermissionsIndex[get_class($record)][$record->getKey()])) {
+            return $this->wildcardPermissionsIndex[get_class($record)][$record->getKey()];
+        }
+
+        return $this->wildcardPermissionsIndex[get_class($record)][$record->getKey()] = app($record->getWildcardClass(), ['record' => $record])->getIndex();
+    }
+
+    public function getCacheRepository(): Repository
+    {
+        return $this->cache;
+    }
+
+    public function getCacheStore(): Store
+    {
+        return $this->cache->getStore();
+    }
+}

--- a/app/Services/Permissions/PermissionLoaderService.php
+++ b/app/Services/Permissions/PermissionLoaderService.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Services\Permissions;
+
+use Illuminate\Database\Eloquent\Collection;
+use RuntimeException;
+
+/**
+ * Service responsible for loading permissions using cache and serialization services.
+ */
+class PermissionLoaderService
+{
+    private const RETRY_LIMIT = 3;
+
+    private Collection|array|null $permissions = null;
+
+    public function __construct(
+        private PermissionCacheService $cache,
+        private PermissionSerializationService $serializer,
+        private string $permissionClass,
+        private string $roleClass
+    ) {
+    }
+
+    public function clearLoadedPermissions(): void
+    {
+        $this->permissions = null;
+    }
+
+    public function loadPermissions(int $retryCount = 0): Collection
+    {
+        if ($this->permissions) {
+            return $this->permissions;
+        }
+
+        $this->permissions = $this->cache->getCacheRepository()->remember(
+            $this->cache->cacheKey,
+            $this->cache->cacheExpirationTime,
+            function () {
+                $permissions = $this->getPermissionsWithRoles();
+
+                return $this->serializer->getSerializedPermissions($permissions);
+            }
+        );
+
+        if (! isset($this->permissions['alias'])) {
+            if ($retryCount >= self::RETRY_LIMIT) {
+                throw new RuntimeException('Failed to load permissions after retrying('.$retryCount.') times.');
+            }
+
+            $this->cache->forgetCachedPermissions();
+            $this->clearLoadedPermissions();
+
+            return $this->loadPermissions($retryCount + 1);
+        }
+
+        $this->serializer->hydrateRolesCache($this->permissions['roles']);
+
+        $hydrated = $this->serializer->getHydratedPermissions($this->permissions['permissions']);
+        $this->clearLoadedPermissions();
+
+        return $hydrated;
+    }
+
+    public function getPermissions(array $params = [], bool $onlyOne = false): Collection
+    {
+        $permissions = $this->loadPermissions();
+
+        $method = $onlyOne ? 'first' : 'filter';
+
+        $result = $permissions->$method(static function ($permission) use ($params) {
+            foreach ($params as $attr => $value) {
+                if ($permission->getAttribute($attr) !== $value) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+
+        if ($onlyOne) {
+            $result = new Collection($result ? [$result] : []);
+        }
+
+        return $result;
+    }
+
+    protected function getPermissionsWithRoles(): Collection
+    {
+        $permissionClass = $this->permissionClass;
+
+        return $permissionClass::select()->with('roles')->get();
+    }
+}

--- a/app/Services/Permissions/PermissionSerializationService.php
+++ b/app/Services/Permissions/PermissionSerializationService.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Services\Permissions;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Permission\Models\Permission;
+
+/**
+ * Handle serialization of permissions for caching.
+ */
+class PermissionSerializationService
+{
+    private array $alias = [];
+
+    private array $cachedRoles = [];
+
+    private array $except = [];
+
+    public function __construct(private string $permissionClass, private string $roleClass)
+    {
+    }
+
+    public function getSerializedPermissions(Collection $permissionsWithRoles): array
+    {
+        $this->except = config('permission.cache.column_names_except', ['created_at', 'updated_at', 'deleted_at']);
+
+        $permissions = $permissionsWithRoles
+            ->map(function ($permission) {
+                if (! $this->alias) {
+                    $this->aliasModelFields($permission);
+                }
+
+                return $this->aliasedArray($permission) + $this->getSerializedRoleRelation($permission);
+            })->all();
+        $roles = array_values($this->cachedRoles);
+        $this->cachedRoles = [];
+
+        return ['alias' => array_flip($this->alias)] + compact('permissions', 'roles');
+    }
+
+    public function getHydratedPermissions(array $permissions): Collection
+    {
+        $permissionInstance = new ($this->permissionClass)();
+
+        return Collection::make(array_map(
+            fn ($item) => $permissionInstance->newInstance([], true)
+                ->setRawAttributes($this->aliasedArray(array_diff_key($item, ['r' => 0])), true)
+                ->setRelation('roles', $this->getHydratedRoleCollection($item['r'] ?? [])),
+            $permissions
+        ));
+    }
+
+    public function hydrateRolesCache(array $roles): void
+    {
+        $roleInstance = new ($this->roleClass)();
+
+        array_map(function ($item) use ($roleInstance) {
+            $role = $roleInstance->newInstance([], true)
+                ->setRawAttributes($this->aliasedArray($item), true);
+            $this->cachedRoles[$role->getKey()] = $role;
+        }, $roles);
+    }
+
+    private function getHydratedRoleCollection(array $roles): Collection
+    {
+        return Collection::make(array_values(
+            array_intersect_key($this->cachedRoles, array_flip($roles))
+        ));
+    }
+
+    private function getSerializedRoleRelation(Permission $permission): array
+    {
+        if (! $permission->roles->count()) {
+            return [];
+        }
+
+        if (! isset($this->alias['roles'])) {
+            $this->alias['roles'] = 'r';
+            $this->aliasModelFields($permission->roles[0]);
+        }
+
+        return [
+            'r' => $permission->roles->map(function ($role) {
+                if (! isset($this->cachedRoles[$role->getKey()])) {
+                    $this->cachedRoles[$role->getKey()] = $this->aliasedArray($role);
+                }
+
+                return $role->getKey();
+            })->all(),
+        ];
+    }
+
+    private function aliasedArray(Model|array $model): array
+    {
+        return collect(is_array($model) ? $model : $model->getAttributes())->except($this->except)
+            ->keyBy(fn ($value, $key) => $this->alias[$key] ?? $key)
+            ->all();
+    }
+
+    private function aliasModelFields(object|array $newKeys = []): void
+    {
+        $i = 0;
+        $alphas = ! count($this->alias) ? range('a', 'h') : range('j', 'p');
+
+        $attributes = is_object($newKeys) && method_exists($newKeys, 'getAttributes') ? $newKeys->getAttributes() : $newKeys;
+
+        foreach (array_keys($attributes) as $value) {
+            if (! isset($this->alias[$value])) {
+                $this->alias[$value] = $alphas[$i++] ?? $value;
+            }
+        }
+
+        $this->alias = array_diff_key($this->alias, array_flip($this->except));
+    }
+}


### PR DESCRIPTION
## Summary
- create PermissionCacheService for caching logic
- create PermissionSerializationService for serializing permission data
- create PermissionLoaderService to handle permission loading
- simplify `PermissionRegistrar` by delegating caching and loading to new services

------
## Summary by Sourcery

Refactor permission management by extracting caching, serialization, and loading responsibilities into dedicated services and simplifying PermissionRegistrar to leverage these services.

New Features:
- Add PermissionCacheService to encapsulate permission caching logic
- Add PermissionSerializationService to handle permission serialization and hydration
- Add PermissionLoaderService to coordinate permission loading with caching and retry support

Enhancements:
- Refactor PermissionRegistrar to delegate cache setup, serialization, and loading to the new services
- Remove legacy inline aliasing, caching, and hydration logic from PermissionRegistrar