### PR TITLE
Potential fix for code scanning alert no. 51: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,4 +1,6 @@
 name: Laravel
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/crimsonstrife/streamer.live/security/code-scanning/51](https://github.com/crimsonstrife/streamer.live/security/code-scanning/51)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the actions and steps in the workflow, the workflow only needs read access to repository contents (`contents: read`). No write permissions are required.

The `permissions` block will be added directly under the `name` key to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
