### PR TITLE
Feature/340 setup onboarding tutorials for site admin and moderators

### DIFF
--- a/app/Filament/Clusters/Integrations/Pages/DiscordSettings.php
+++ b/app/Filament/Clusters/Integrations/Pages/DiscordSettings.php
@@ -51,4 +51,15 @@ class DiscordSettings extends SettingsPage
                     ->columns(2),
             ]);
     }
+
+    public function mount(): void
+    {
+        parent::mount();
+
+        if ( auth()->user()?->can('is-admin') or auth()->user()?->can('is-super-admin'))
+        {
+            auth()->user()?->markOnboardingStepComplete('visited_discord_integration_page');
+        }
+    }
+
 }

--- a/app/Filament/Clusters/Integrations/Pages/DiscordSettings.php
+++ b/app/Filament/Clusters/Integrations/Pages/DiscordSettings.php
@@ -56,8 +56,7 @@ class DiscordSettings extends SettingsPage
     {
         parent::mount();
 
-        if ( auth()->user()?->can('is-admin') or auth()->user()?->can('is-super-admin'))
-        {
+        if (auth()->user()?->can('is-admin') or auth()->user()?->can('is-super-admin')) {
             auth()->user()?->markOnboardingStepComplete('visited_discord_integration_page');
         }
     }

--- a/app/Filament/Clusters/Integrations/Pages/FourthwallSettings.php
+++ b/app/Filament/Clusters/Integrations/Pages/FourthwallSettings.php
@@ -81,8 +81,7 @@ class FourthwallSettings extends SettingsPage
     {
         parent::mount();
 
-        if ( auth()->user()?->can('is-admin') or auth()->user()?->can('is-super-admin'))
-        {
+        if (auth()->user()?->can('is-admin') or auth()->user()?->can('is-super-admin')) {
             auth()->user()?->markOnboardingStepComplete('visited_fourthwall_integration_page');
         }
     }

--- a/app/Filament/Clusters/Integrations/Pages/FourthwallSettings.php
+++ b/app/Filament/Clusters/Integrations/Pages/FourthwallSettings.php
@@ -76,4 +76,15 @@ class FourthwallSettings extends SettingsPage
                     ->columns(2),
             ]);
     }
+
+    public function mount(): void
+    {
+        parent::mount();
+
+        if ( auth()->user()?->can('is-admin') or auth()->user()?->can('is-super-admin'))
+        {
+            auth()->user()?->markOnboardingStepComplete('visited_fourthwall_integration_page');
+        }
+    }
+
 }

--- a/app/Filament/Clusters/Integrations/Pages/TwitchSettings.php
+++ b/app/Filament/Clusters/Integrations/Pages/TwitchSettings.php
@@ -138,8 +138,7 @@ class TwitchSettings extends SettingsPage
     {
         parent::mount();
 
-        if ( auth()->user()?->can('is-admin') or auth()->user()?->can('is-super-admin'))
-        {
+        if (auth()->user()?->can('is-admin') or auth()->user()?->can('is-super-admin')) {
             auth()->user()?->markOnboardingStepComplete('visited_twitch_integration_page');
         }
     }

--- a/app/Filament/Clusters/Integrations/Pages/TwitchSettings.php
+++ b/app/Filament/Clusters/Integrations/Pages/TwitchSettings.php
@@ -133,4 +133,14 @@ class TwitchSettings extends SettingsPage
                 ->color('secondary'),
         ];
     }
+
+    public function mount(): void
+    {
+        parent::mount();
+
+        if ( auth()->user()?->can('is-admin') or auth()->user()?->can('is-super-admin'))
+        {
+            auth()->user()?->markOnboardingStepComplete('visited_twitch_integration_page');
+        }
+    }
 }

--- a/app/Filament/Widgets/AccountWidget.php
+++ b/app/Filament/Widgets/AccountWidget.php
@@ -27,7 +27,7 @@ class AccountWidget extends Widget
         $panel = Filament::getCurrentPanel();
 
         if ($user && $panel) {
-            Log::info('Registering onboarding from AccountWidget', [
+            Log::debug('Registering onboarding from AccountWidget', [
                 'user_id' => $user->id,
                 'panel' => $panel->getId(),
             ]);

--- a/app/Filament/Widgets/AccountWidget.php
+++ b/app/Filament/Widgets/AccountWidget.php
@@ -3,41 +3,83 @@
 namespace App\Filament\Widgets;
 
 use App\Services\OnboardingStepRegistrar;
+use Exception;
 use Filament\Facades\Filament;
 use Filament\Widgets\Widget;
 use Illuminate\Support\Facades\Log;
 
+/**
+ * Class AccountWidget
+ *
+ * A Filament widget responsible for managing user onboarding steps within the account panel.
+ * This widget ensures onboarding steps are registered for authenticated users and their respective panels.
+ */
 class AccountWidget extends Widget
 {
+    /**
+     * @var int|null Determines the sort order of the widget. Lower values appear earlier.
+     */
     protected static ?int $sort = -3;
 
+    /**
+     * @var bool Indicates whether onboarding steps have been registered.
+     */
     protected static bool $stepsRegistered = false;
 
-    protected static bool $isLazy = false; // must be false so mount() runs immediately
+    /**
+     * @var bool Specifies whether the widget should load lazily. Must be false for immediate execution.
+     */
+    protected static bool $isLazy = false;
 
+    /**
+     * @var string The view file associated with the widget.
+     */
     protected static string $view = 'filament.widgets.account-widget';
 
+    /**
+     * Mounts the widget and registers onboarding steps for the authenticated user and panel.
+     *
+     * This method is executed immediately when the widget is loaded.
+     *
+     * @throws Exception If an error occurs during onboarding step registration.
+     */
     public function mount(): void
     {
-        if (static::$stepsRegistered) {
-            return;
-        }
-
+        // Retrieve the authenticated user and current panel.
         $user = Filament::auth()?->user();
         $panel = Filament::getCurrentPanel();
 
-        if ($user && $panel) {
-            Log::debug('Registering onboarding from AccountWidget', [
-                'user_id' => $user->id,
-                'panel' => $panel->getId(),
-            ]);
-            (new OnboardingStepRegistrar())->register($panel, $user);
-            static::$stepsRegistered = true;
-        } else {
-            Log::info('Onboarding skipped in widget: user or panel missing', [
+        // Log and skip onboarding if user or panel is missing.
+        if (! $user || ! $panel) {
+            Log::debug('Onboarding skipped in widget: user or panel missing', [
                 'user' => $user,
                 'panel' => $panel?->getId(),
             ]);
+
+            return;
         }
+
+        // Generate a unique key for the user and panel combination.
+        $key = spl_object_hash($user).'|'.$panel->getId();
+
+        // Static array to track registered users and panels.
+        static $registeredUsers = [];
+
+        // Skip registration if the user and panel combination is already registered.
+        if (in_array($key, $registeredUsers, true)) {
+            return;
+        }
+
+        // Log the registration process for debugging purposes.
+        Log::debug('Registering onboarding from AccountWidget', [
+            'user_id' => $user->id,
+            'panel' => $panel->getId(),
+        ]);
+
+        // Register onboarding steps using the OnboardingStepRegistrar service.
+        (new OnboardingStepRegistrar)->register($panel, $user);
+
+        // Mark the user and panel combination as registered.
+        $registeredUsers[] = $key;
     }
 }

--- a/app/Filament/Widgets/AccountWidget.php
+++ b/app/Filament/Widgets/AccountWidget.php
@@ -31,7 +31,7 @@ class AccountWidget extends Widget
                 'user_id' => $user->id,
                 'panel' => $panel->getId(),
             ]);
-            (new OnboardingStepRegistrar)->register($panel, $user);
+            (new OnboardingStepRegistrar())->register($panel, $user);
             static::$stepsRegistered = true;
         } else {
             Log::warning('Onboarding skipped in widget: user or panel missing', [

--- a/app/Filament/Widgets/AccountWidget.php
+++ b/app/Filament/Widgets/AccountWidget.php
@@ -6,20 +6,19 @@ use App\Services\OnboardingStepRegistrar;
 use Filament\Facades\Filament;
 use Filament\Widgets\Widget;
 use Illuminate\Support\Facades\Log;
-use Spatie\Onboard\Facades\Onboard;
 
 class AccountWidget extends Widget
 {
     protected static ?int $sort = -3;
+
     protected static bool $stepsRegistered = false;
+
     protected static bool $isLazy = false; // must be false so mount() runs immediately
+
     protected static string $view = 'filament.widgets.account-widget';
 
     public function mount(): void
     {
-        $user = Filament::auth()?->user();
-        $panel = Filament::getCurrentPanel();
-
         if (static::$stepsRegistered) {
             return;
         }

--- a/app/Filament/Widgets/AccountWidget.php
+++ b/app/Filament/Widgets/AccountWidget.php
@@ -34,7 +34,7 @@ class AccountWidget extends Widget
             (new OnboardingStepRegistrar())->register($panel, $user);
             static::$stepsRegistered = true;
         } else {
-            Log::warning('Onboarding skipped in widget: user or panel missing', [
+            Log::info('Onboarding skipped in widget: user or panel missing', [
                 'user' => $user,
                 'panel' => $panel?->getId(),
             ]);

--- a/app/Filament/Widgets/AccountWidget.php
+++ b/app/Filament/Widgets/AccountWidget.php
@@ -2,13 +2,43 @@
 
 namespace App\Filament\Widgets;
 
+use App\Services\OnboardingStepRegistrar;
+use Filament\Facades\Filament;
 use Filament\Widgets\Widget;
+use Illuminate\Support\Facades\Log;
+use Spatie\Onboard\Facades\Onboard;
 
 class AccountWidget extends Widget
 {
     protected static ?int $sort = -3;
-
-    protected static bool $isLazy = false;
-
+    protected static bool $stepsRegistered = false;
+    protected static bool $isLazy = false; // must be false so mount() runs immediately
     protected static string $view = 'filament.widgets.account-widget';
+
+    public function mount(): void
+    {
+        $user = Filament::auth()?->user();
+        $panel = Filament::getCurrentPanel();
+
+        if (static::$stepsRegistered) {
+            return;
+        }
+
+        $user = Filament::auth()?->user();
+        $panel = Filament::getCurrentPanel();
+
+        if ($user && $panel) {
+            Log::info('Registering onboarding from AccountWidget', [
+                'user_id' => $user->id,
+                'panel' => $panel->getId(),
+            ]);
+            (new OnboardingStepRegistrar)->register($panel, $user);
+            static::$stepsRegistered = true;
+        } else {
+            Log::warning('Onboarding skipped in widget: user or panel missing', [
+                'user' => $user,
+                'panel' => $panel?->getId(),
+            ]);
+        }
+    }
 }

--- a/app/Filament/Widgets/AccountWidget.php
+++ b/app/Filament/Widgets/AccountWidget.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use Filament\Widgets\Widget;
+
+class AccountWidget extends Widget
+{
+    protected static ?int $sort = -3;
+
+    protected static bool $isLazy = false;
+
+    protected static string $view = 'filament.widgets.account-widget';
+}

--- a/app/Filament/Widgets/AccountWidget.php
+++ b/app/Filament/Widgets/AccountWidget.php
@@ -77,7 +77,7 @@ class AccountWidget extends Widget
         ]);
 
         // Register onboarding steps using the OnboardingStepRegistrar service.
-        (new OnboardingStepRegistrar)->register($panel, $user);
+        (new OnboardingStepRegistrar())->register($panel, $user);
 
         // Mark the user and panel combination as registered.
         $registeredUsers[] = $key;

--- a/app/Http/Controllers/OnboardingController.php
+++ b/app/Http/Controllers/OnboardingController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Class OnboardingController
+ *
+ * Controller responsible for handling onboarding-related actions for users.
+ */
+class OnboardingController extends Controller
+{
+    /**
+     * Dismisses the onboarding process for the authenticated user.
+     *
+     * Marks the onboarding process as dismissed for the user and redirects them
+     * back to the previous page with a success message.
+     *
+     * @param  Request  $request  The incoming HTTP request.
+     * @return RedirectResponse A redirect response back to the previous page with a success message.
+     */
+    public function dismiss(Request $request): RedirectResponse
+    {
+        // Call the dismissOnboarding method on the authenticated user.
+        $request->user()->dismissOnboarding();
+
+        // Redirect back with a success message.
+        return redirect()->back()->with('message', 'Onboarding dismissed.');
+    }
+}

--- a/app/Livewire/OnboardingWidget.php
+++ b/app/Livewire/OnboardingWidget.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Livewire;
+
+use Filament\Widgets\Widget;
+
+class OnboardingWidget extends Widget
+{
+    protected static string $view = 'livewire.onboarding-widget';
+
+    protected static ?string $heading = 'Setup Guide';
+}

--- a/app/Livewire/UpcomingStream.php
+++ b/app/Livewire/UpcomingStream.php
@@ -2,9 +2,9 @@
 
 namespace App\Livewire;
 
-use Filament\Widgets\Widget;
 use App\Models\Event;
 use Carbon\Carbon;
+use Filament\Widgets\Widget;
 
 class UpcomingStream extends Widget
 {
@@ -14,8 +14,8 @@ class UpcomingStream extends Widget
 
     protected function getViewData(): array
     {
-        $now   = Carbon::now();
-        $soon  = $now->copy()->addMinutes(15);
+        $now = Carbon::now();
+        $soon = $now->copy()->addMinutes(15);
 
         $events = Event::query()
             ->where('starts_at', '>=', $now)
@@ -25,7 +25,7 @@ class UpcomingStream extends Widget
 
         return [
             // we still call them streams for context, but they're your Event models
-            'streams'       => $events,
+            'streams' => $events,
             'soonThreshold' => $soon,
         ];
     }

--- a/app/Models/AuthObjects/User.php
+++ b/app/Models/AuthObjects/User.php
@@ -7,11 +7,8 @@ use App\Models\BlogObjects\Author;
 use App\Models\SharedObjects\OnboardingProgress;
 use App\Traits\HasAdvancedPermissions;
 use App\Traits\IsPermissible;
-use Database\Factories\AuthObjects\UserFactory;
-use Eloquent;
 use Filament\Models\Contracts\HasAvatar;
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -35,78 +32,47 @@ use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Traits\HasRoles;
 
 /**
- * @property int $id
- * @property string $username
- * @property string|null $first_name
- * @property string|null $last_name
- * @property string $display_name
- * @property string $email
- * @property Carbon|null $email_verified_at
- * @property Carbon $birthdate
- * @property string|null $pronouns
- * @property string|null $location
- * @property string $password
- * @property string|null $two_factor_secret
- * @property string|null $two_factor_recovery_codes
- * @property string|null $two_factor_confirmed_at
- * @property string|null $remember_token
- * @property int|null $current_team_id
- * @property string|null $profile_photo_path
- * @property Carbon|null $created_at
- * @property Carbon|null $updated_at
- * @property string|null $custom_fields
- * @property-read Collection<int, Ban> $bans
- * @property-read int|null $bans_count
- * @property-read string $filament_banhammer_title
- * @property-read string|null $full_name
- * @property-read string $name
- * @property-read DatabaseNotificationCollection<int, DatabaseNotification> $notifications
- * @property-read int|null $notifications_count
- * @property-read Collection<int, Permission> $permissions
- * @property-read int|null $permissions_count
- * @property-read string $profile_photo_url
- * @property-read Collection<int, \Spatie\Permission\Models\Role> $roles
- * @property-read int|null $roles_count
- * @property-read Collection<int, PersonalAccessToken> $tokens
- * @property-read int|null $tokens_count
+ * Class User
  *
- * @method static Builder<static>|User banned(bool $banned = true)
- * @method static Builder<static>|User bannedByType(string $className)
- * @method static UserFactory factory($count = null, $state = [])
- * @method static Builder<static>|User newModelQuery()
- * @method static Builder<static>|User newQuery()
- * @method static Builder<static>|User notBanned()
- * @method static Builder<static>|User permission($permissions, $without = false)
- * @method static Builder<static>|User query()
- * @method static Builder<static>|User role($roles, $guard = null, $without = false)
- * @method static Builder<static>|User whereBansMeta(string $key, $value)
- * @method static Builder<static>|User whereBirthdate($value)
- * @method static Builder<static>|User whereCreatedAt($value)
- * @method static Builder<static>|User whereCurrentTeamId($value)
- * @method static Builder<static>|User whereCustomFields($value)
- * @method static Builder<static>|User whereDisplayName($value)
- * @method static Builder<static>|User whereEmail($value)
- * @method static Builder<static>|User whereEmailVerifiedAt($value)
- * @method static Builder<static>|User whereFirstName($value)
- * @method static Builder<static>|User whereId($value)
- * @method static Builder<static>|User whereLastName($value)
- * @method static Builder<static>|User whereLocation($value)
- * @method static Builder<static>|User wherePassword($value)
- * @method static Builder<static>|User whereProfilePhotoPath($value)
- * @method static Builder<static>|User wherePronouns($value)
- * @method static Builder<static>|User whereRememberToken($value)
- * @method static Builder<static>|User whereTwoFactorConfirmedAt($value)
- * @method static Builder<static>|User whereTwoFactorRecoveryCodes($value)
- * @method static Builder<static>|User whereTwoFactorSecret($value)
- * @method static Builder<static>|User whereUpdatedAt($value)
- * @method static Builder<static>|User whereUsername($value)
- * @method static Builder<static>|User withoutPermission($permissions)
- * @method static Builder<static>|User withoutRole($roles, $guard = null)
+ * Represents a user in the application, including authentication, permissions, and onboarding progress.
  *
- * @mixin Eloquent
+ * @property int $id The unique identifier for the user.
+ * @property string $username The username of the user.
+ * @property string|null $first_name The first name of the user.
+ * @property string|null $last_name The last name of the user.
+ * @property string $display_name The display name of the user.
+ * @property string $email The email address of the user.
+ * @property Carbon|null $email_verified_at The timestamp when the user's email was verified.
+ * @property Carbon $birthdate The birthdate of the user.
+ * @property string|null $pronouns The pronouns of the user.
+ * @property string|null $location The location of the user.
+ * @property string $password The hashed password of the user.
+ * @property string|null $two_factor_secret The secret for two-factor authentication.
+ * @property string|null $two_factor_recovery_codes The recovery codes for two-factor authentication.
+ * @property string|null $two_factor_confirmed_at The timestamp when two-factor authentication was confirmed.
+ * @property string|null $remember_token The token used for "remember me" functionality.
+ * @property int|null $current_team_id The ID of the user's current team.
+ * @property string|null $profile_photo_path The path to the user's profile photo.
+ * @property Carbon|null $created_at The timestamp when the user was created.
+ * @property Carbon|null $updated_at The timestamp when the user was last updated.
+ * @property string|null $custom_fields Custom fields associated with the user.
+ * @property-read Collection<int, Ban> $bans The bans associated with the user.
+ * @property-read int|null $bans_count The count of bans associated with the user.
+ * @property-read string $filament_banhammer_title The title used for the Filament Banhammer.
+ * @property-read string|null $full_name The full name of the user.
+ * @property-read string $name The name of the user.
+ * @property-read DatabaseNotificationCollection<int, DatabaseNotification> $notifications The notifications for the user.
+ * @property-read int|null $notifications_count The count of notifications for the user.
+ * @property-read Collection<int, Permission> $permissions The permissions assigned to the user.
+ * @property-read int|null $permissions_count The count of permissions assigned to the user.
+ * @property-read string $profile_photo_url The URL of the user's profile photo.
+ * @property-read Collection<int, \Spatie\Permission\Models\Role> $roles The roles assigned to the user.
+ * @property-read int|null $roles_count The count of roles assigned to the user.
+ * @property-read Collection<int, PersonalAccessToken> $tokens The personal access tokens for the user.
+ * @property-read int|null $tokens_count The count of personal access tokens for the user.
  */
 #[AllowDynamicProperties]
-class User extends Authenticatable implements HasAvatar, Onboardable
+class User extends Authenticatable implements HasAvatar, MustVerifyEmail, Onboardable
 {
     use Bannable;
     use GetsOnboarded;
@@ -115,10 +81,7 @@ class User extends Authenticatable implements HasAvatar, Onboardable
         HasAdvancedPermissions::hasPermissionTo insteadof HasRoles;
     }
     use HasApiTokens;
-
-    /** @use HasFactory<UserFactory> */
     use HasFactory;
-
     use HasProfilePhoto;
     use IsPermissible;
     use Notifiable;
@@ -146,7 +109,7 @@ class User extends Authenticatable implements HasAvatar, Onboardable
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'birthdate' => 'date',
@@ -188,6 +151,8 @@ class User extends Authenticatable implements HasAvatar, Onboardable
 
     /**
      * Get the title attribute for the Filament Banhammer.
+     *
+     * @return string The title used for the Filament Banhammer.
      */
     public function getFilamentBanhammerTitleAttribute(): string
     {
@@ -197,7 +162,7 @@ class User extends Authenticatable implements HasAvatar, Onboardable
     /**
      * Get the attributes that should be cast.
      *
-     * @return array<string, string>
+     * @return array<string, string> The attributes and their cast types.
      */
     protected function casts(): array
     {
@@ -257,18 +222,28 @@ class User extends Authenticatable implements HasAvatar, Onboardable
     /**
      * Get the user's last name.
      *
-     * @return string|null The user's last name.
+     * @return string|null The last name of the user.
      */
     public function getLastNameAttribute(): ?string
     {
         return $this->last_name ?? null;
     }
 
+    /**
+     * Define a one-to-one relationship with the Author model.
+     *
+     * @return HasOne The relationship instance.
+     */
     public function blogAuthor(): HasOne
     {
         return $this->hasOne(Author::class);
     }
 
+    /**
+     * Get the user's Twitch token if it is valid.
+     *
+     * @return string|null The Twitch token, or null if expired or not set.
+     */
     public function getTwitchToken(): ?string
     {
         if ($this->twitch_user_token && now()->lt($this->twitch_user_expires_at)) {
@@ -278,6 +253,12 @@ class User extends Authenticatable implements HasAvatar, Onboardable
         return null;
     }
 
+    /**
+     * Check if the user has completed a specific onboarding step.
+     *
+     * @param  string  $key  The key of the onboarding step.
+     * @return bool True if the step is completed, false otherwise.
+     */
     public function hasCompletedOnboardingStep(string $key): bool
     {
         return $this->onboardingProgress()
@@ -286,6 +267,11 @@ class User extends Authenticatable implements HasAvatar, Onboardable
             ->exists();
     }
 
+    /**
+     * Mark a specific onboarding step as complete for the user.
+     *
+     * @param  string  $key  The key of the onboarding step.
+     */
     public function markOnboardingStepComplete(string $key): void
     {
         $this->onboardingProgress()->updateOrCreate(
@@ -294,9 +280,36 @@ class User extends Authenticatable implements HasAvatar, Onboardable
         );
     }
 
+    /**
+     * Define a one-to-many relationship with the OnboardingProgress model.
+     *
+     * @return HasMany The relationship instance.
+     */
     public function onboardingProgress(): HasMany
     {
         return $this->hasMany(OnboardingProgress::class);
     }
 
+    /**
+     * Check if the user has dismissed the onboarding process.
+     *
+     * @return bool True if onboarding is dismissed, false otherwise.
+     */
+    public function hasDismissedOnboarding(): bool
+    {
+        return $this->onboardingProgress()
+            ->where('step_key', 'onboarding.dismissed')
+            ->exists();
+    }
+
+    /**
+     * Dismiss the onboarding process for the user.
+     */
+    public function dismissOnboarding(): void
+    {
+        $this->onboardingProgress()->updateOrCreate(
+            ['step_key' => 'onboarding.dismissed'],
+            ['completed_at' => now()]
+        );
+    }
 }

--- a/app/Models/AuthObjects/User.php
+++ b/app/Models/AuthObjects/User.php
@@ -4,6 +4,7 @@ namespace App\Models\AuthObjects;
 
 use AllowDynamicProperties;
 use App\Models\BlogObjects\Author;
+use App\Models\SharedObjects\OnboardingProgress;
 use App\Traits\HasAdvancedPermissions;
 use App\Traits\IsPermissible;
 use Database\Factories\AuthObjects\UserFactory;
@@ -14,6 +15,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -275,4 +277,26 @@ class User extends Authenticatable implements HasAvatar, Onboardable
 
         return null;
     }
+
+    public function hasCompletedOnboardingStep(string $key): bool
+    {
+        return $this->onboardingProgress()
+            ->where('step_key', $key)
+            ->whereNotNull('completed_at')
+            ->exists();
+    }
+
+    public function markOnboardingStepComplete(string $key): void
+    {
+        $this->onboardingProgress()->updateOrCreate(
+            ['step_key' => $key],
+            ['completed_at' => now()]
+        );
+    }
+
+    public function onboardingProgress(): HasMany
+    {
+        return $this->hasMany(OnboardingProgress::class);
+    }
+
 }

--- a/app/Models/Settings.php
+++ b/app/Models/Settings.php
@@ -14,9 +14,13 @@ use Spatie\LaravelSettings\Settings as SpatieSettings;
 use Spatie\LaravelSettings\SettingsConfig;
 use Spatie\LaravelSettings\SettingsRepositories\SettingsRepository;
 use Spatie\LaravelSettings\Support\Crypto;
+use Spatie\Onboard\Concerns\GetsOnboarded;
+use Spatie\Onboard\Concerns\Onboardable;
 
-abstract class Settings extends SpatieSettings
+abstract class Settings extends SpatieSettings implements Onboardable
 {
+    use GetsOnboarded;
+
     private SettingsMapper $mapper;
 
     private SettingsConfig $config;
@@ -112,8 +116,8 @@ abstract class Settings extends SpatieSettings
 
     public function __serialize(): array
     {
-        /** @var \App\Models\StoreObjects\Collection $encrypted */
-        /** @var \App\Models\StoreObjects\Collection $nonEncrypted */
+        /** @var StoreObjects\Collection $encrypted */
+        /** @var StoreObjects\Collection $nonEncrypted */
         [$encrypted, $nonEncrypted] = $this->toCollection()->partition(
             fn ($value, string $name) => $this->config->isEncrypted($name)
         );
@@ -130,8 +134,8 @@ abstract class Settings extends SpatieSettings
 
         $this->ensureConfigIsLoaded();
 
-        /** @var \App\Models\StoreObjects\Collection $encrypted */
-        /** @var \App\Models\StoreObjects\Collection $nonEncrypted */
+        /** @var StoreObjects\Collection $encrypted */
+        /** @var StoreObjects\Collection $nonEncrypted */
         [$encrypted, $nonEncrypted] = collect($data)->partition(
             fn ($value, string $name) => $this->config->isEncrypted($name)
         );
@@ -145,7 +149,7 @@ abstract class Settings extends SpatieSettings
     }
 
     /**
-     * @param  \App\Models\StoreObjects\Collection|array  $properties
+     * @param  StoreObjects\Collection|array  $properties
      * @return $this
      */
     public function fill($properties): self

--- a/app/Models/SharedObjects/OnboardingProgress.php
+++ b/app/Models/SharedObjects/OnboardingProgress.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models\SharedObjects;
+
+use App\Models\AuthObjects\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OnboardingProgress extends Model
+{
+    protected $fillable = ['user_id', 'step_key', 'completed_at'];
+
+    protected $casts = [
+        'completed_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use App\Models\BlogObjects\Comment;
 use App\Observers\CommentObserver;
 use App\Services\CustomMediaPathGenerator;
 use App\Services\FourthwallService;
+use App\Services\OnboardingStepRegistrar;
 use App\Services\SecureGuestModeService;
 use App\Services\Spam\AkismetEvaluator;
 use App\Services\Spam\BlacklistEvaluator;
@@ -24,6 +25,7 @@ use App\Utilities\ShopHelper;
 use App\Utilities\StreamHelper;
 use App\View\Helpers\ViewHelpers;
 use Exception;
+use Filament\Facades\Filament;
 use Filament\FilamentManager;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
@@ -151,15 +153,5 @@ class AppServiceProvider extends ServiceProvider
             'profile.update-profile-information-form',
             AppUpdateProfile::class
         );
-
-        Onboard::addStep('Set your site settings!')
-            ->link('/admin/settings/site-settings')
-            ->cta('Configure')
-            ->completeIf(function (SiteSettings $setting) {
-                return $setting->isComplete() === true;
-            })
-            ->excludeIf(function (User $model) {
-                return ! $model->can('is-super-admin') or ! $model->can('is-admin');
-            });
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -80,7 +80,7 @@ class AppServiceProvider extends ServiceProvider
             );
         });
 
-        $this->app->singleton('secure-guest-mode', fn ($app) => new SecureGuestModeService);
+        $this->app->singleton('secure-guest-mode', fn ($app) => new SecureGuestModeService());
 
         $this->app->tag(
             [

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -116,6 +116,7 @@ class AdminPanelProvider extends PanelProvider
             ->default()
             ->id('admin')
             ->path('admin')
+            ->authGuard('web')
             ->login()
             ->registration()
             ->passwordReset()

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers\Filament;
 
 use App\Filament\Pages;
 use App\Filament\Resources;
+use App\Filament\Widgets\AccountWidget;
 use App\Listeners\SwitchTeam;
 use App\Livewire\CurrentStreamStatus;
 use App\Livewire\PanelCalendarWidget;
@@ -150,7 +151,7 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->discoverWidgets(in: app_path('Filament/Admin/Widgets'), for: 'App\\Filament\\Admin\\Widgets')
             ->widgets([
-                Widgets\AccountWidget::class,
+                AccountWidget::class,
                 Widgets\FilamentInfoWidget::class,
                 CurrentStreamStatus::class,
                 UpcomingStream::class,

--- a/app/Providers/Filament/DeveloperPanelProvider.php
+++ b/app/Providers/Filament/DeveloperPanelProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Widgets\AccountWidget;
+use Exception;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -23,7 +25,7 @@ use Stephenjude\FilamentDebugger\DebuggerPlugin;
 class DeveloperPanelProvider extends PanelProvider
 {
     /**
-     * @throws \Exception
+     * @throws Exception
      */
     public function panel(Panel $panel): Panel
     {
@@ -45,7 +47,7 @@ class DeveloperPanelProvider extends PanelProvider
             ])
             ->discoverWidgets(in: app_path('Filament/Developer/Widgets'), for: 'App\\Filament\\Developer\\Widgets')
             ->widgets([
-                Widgets\AccountWidget::class,
+                AccountWidget::class,
                 Widgets\FilamentInfoWidget::class,
             ])
             ->middleware([

--- a/app/Providers/Filament/DeveloperPanelProvider.php
+++ b/app/Providers/Filament/DeveloperPanelProvider.php
@@ -30,6 +30,7 @@ class DeveloperPanelProvider extends PanelProvider
         return $panel
             ->id('developer')
             ->path('dev')
+            ->authGuard('web')
             ->login()
             ->registration()
             ->passwordReset()

--- a/app/Providers/Filament/ModerationPanelProvider.php
+++ b/app/Providers/Filament/ModerationPanelProvider.php
@@ -33,6 +33,7 @@ class ModerationPanelProvider extends PanelProvider
         return $panel
             ->id('moderation')
             ->path('moderation')
+            ->authGuard('web')
             ->login()
             ->registration()
             ->passwordReset()

--- a/app/Providers/Filament/ModerationPanelProvider.php
+++ b/app/Providers/Filament/ModerationPanelProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers\Filament;
 
 use App\Filament\Pages;
 use App\Filament\Resources;
+use App\Filament\Widgets\AccountWidget;
 use App\Plugins\BanPlugin;
 use Exception;
 use Filament\Http\Middleware\Authenticate;
@@ -56,7 +57,7 @@ class ModerationPanelProvider extends PanelProvider
             ])
             ->discoverWidgets(in: app_path('Filament/Moderation/Widgets'), for: 'App\\Filament\\Moderation\\Widgets')
             ->widgets([
-                Widgets\AccountWidget::class,
+                AccountWidget::class,
                 Widgets\FilamentInfoWidget::class,
             ])
             ->discoverClusters(in: app_path('Filament/Clusters'), for: 'App\\Filament\\Clusters')

--- a/app/Providers/OnboardingServiceProvider.php
+++ b/app/Providers/OnboardingServiceProvider.php
@@ -3,23 +3,31 @@
 namespace App\Providers;
 
 use App\Services\OnboardingStepRegistrar;
-use Filament\Events\ServingFilament;
 use Filament\Facades\Filament;
 use Illuminate\Support\ServiceProvider;
 use Spatie\Onboard\Facades\Onboard;
 
+/**
+ * Class OnboardingServiceProvider
+ *
+ * Service provider for managing onboarding steps within the application.
+ */
 class OnboardingServiceProvider extends ServiceProvider
 {
     /**
      * Register services.
+     *
+     * This method is used to bind services into the container.
      */
     public function register(): void
     {
-        //
+        // No services are registered in this provider.
     }
 
     /**
      * Bootstrap services.
+     *
+     * This method is used to initialize services and perform any necessary setup.
      */
     public function boot(): void
     {
@@ -29,12 +37,7 @@ class OnboardingServiceProvider extends ServiceProvider
                 $user = Filament::auth()?->user();
 
                 if ($panel && $user) {
-                    (new OnboardingStepRegistrar())->register($panel, $user);
-                } else {
-                    logger()->warning('Onboarding skipped: panel or user missing.', [
-                        'panel' => $panel?->getId(),
-                        'user_id' => $user?->id,
-                    ]);
+                    (new OnboardingStepRegistrar)->register($panel, $user);
                 }
             });
         }

--- a/app/Providers/OnboardingServiceProvider.php
+++ b/app/Providers/OnboardingServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Providers;
+
+use App\Services\OnboardingStepRegistrar;
+use Filament\Events\ServingFilament;
+use Filament\Facades\Filament;
+use Illuminate\Support\ServiceProvider;
+use Spatie\Onboard\Facades\Onboard;
+
+class OnboardingServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        if (class_exists(Onboard::class)) {
+            Filament::serving(function () {
+                $panel = Filament::getCurrentPanel();
+                $user = Filament::auth()?->user();
+
+                if ($panel && $user) {
+                    (new OnboardingStepRegistrar)->register($panel, $user);
+                } else {
+                    logger()->warning('Onboarding skipped: panel or user missing.', [
+                        'panel' => $panel?->getId(),
+                        'user_id' => $user?->id,
+                    ]);
+                }
+            });
+        }
+    }
+}

--- a/app/Providers/OnboardingServiceProvider.php
+++ b/app/Providers/OnboardingServiceProvider.php
@@ -29,7 +29,7 @@ class OnboardingServiceProvider extends ServiceProvider
                 $user = Filament::auth()?->user();
 
                 if ($panel && $user) {
-                    (new OnboardingStepRegistrar)->register($panel, $user);
+                    (new OnboardingStepRegistrar())->register($panel, $user);
                 } else {
                     logger()->warning('Onboarding skipped: panel or user missing.', [
                         'panel' => $panel?->getId(),

--- a/app/Providers/OnboardingServiceProvider.php
+++ b/app/Providers/OnboardingServiceProvider.php
@@ -37,7 +37,7 @@ class OnboardingServiceProvider extends ServiceProvider
                 $user = Filament::auth()?->user();
 
                 if ($panel && $user) {
-                    (new OnboardingStepRegistrar)->register($panel, $user);
+                    (new OnboardingStepRegistrar())->register($panel, $user);
                 }
             });
         }

--- a/app/Services/OnboardingStepRegistrar.php
+++ b/app/Services/OnboardingStepRegistrar.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\AuthObjects\User;
 use App\Settings\SiteSettings;
+use Exception;
 use Filament\Panel;
 use Spatie\Onboard\Facades\Onboard;
 
@@ -29,11 +30,14 @@ class OnboardingStepRegistrar
 
         match ($panelSlug) {
             'admin' => $this->registerAdminSteps($panel, $user),
-            'moderator' => $this->registerModeratorSteps($panel, $user),
+            'moderation' => $this->registerModeratorSteps($panel, $user),
             default => null,
         };
     }
 
+    /**
+     * @throws Exception
+     */
     protected function registerAdminSteps(?Panel $panel = null, ?User $user = null): void
     {
         $panelSlug = $panel?->getId() ?? 'admin';
@@ -51,6 +55,9 @@ class OnboardingStepRegistrar
         $this->addOptionalIntegrationSteps($panel, $user);
     }
 
+    /**
+     * @throws Exception
+     */
     protected function registerModeratorSteps(?Panel $panel = null, ?User $user = null): void
     {
         $panelSlug = $panel?->getId() ?? 'admin';
@@ -66,6 +73,9 @@ class OnboardingStepRegistrar
         $this->addOptionalIntegrationSteps($panel, $user);
     }
 
+    /**
+     * @throws Exception
+     */
     protected function addOptionalIntegrationSteps(?Panel $panel = null, ?User $user = null): void
     {
         $panelSlug = $panel?->getId() ?? 'admin';

--- a/app/Services/OnboardingStepRegistrar.php
+++ b/app/Services/OnboardingStepRegistrar.php
@@ -65,6 +65,7 @@ class OnboardingStepRegistrar
 
         $this->addStepOnce('moderator-blog-comments', function () use ($panelSlug, $user) {
             Onboard::addStep('Review flagged comments')
+                ->key('visited_blog_comments')
                 ->link("/{$panelSlug}/blog/comments")
                 ->cta('Review')
                 ->completeIf(fn () => $user->hasCompletedOnboardingStep('visited_blog_comments'))

--- a/app/Services/OnboardingStepRegistrar.php
+++ b/app/Services/OnboardingStepRegistrar.php
@@ -44,6 +44,7 @@ class OnboardingStepRegistrar
 
         $this->addStepOnce('site-settings', function () use ($panelSlug, $user) {
             Onboard::addStep('Set your site settings!')
+                ->key('site-settings')
                 ->link("/{$panelSlug}/settings/site-settings")
                 ->cta('Configure')
                 ->completeIf(fn (SiteSettings $setting) => $setting->isComplete())

--- a/app/Services/OnboardingStepRegistrar.php
+++ b/app/Services/OnboardingStepRegistrar.php
@@ -84,6 +84,7 @@ class OnboardingStepRegistrar
         foreach (['discord', 'fourthwall', 'twitch'] as $slug) {
             $this->addStepOnce("optional-integration-{$slug}", function () use ($panelSlug, $slug, $user) {
                 Onboard::addStep("Visit the {$slug} integration settings")
+                    ->key("visited_{$slug}_integration_page")
                     ->link("/{$panelSlug}/integrations/{$slug}-settings")
                     ->cta('See Optional Features')
                     ->completeIf(fn () => $user->hasCompletedOnboardingStep("visited_{$slug}_integration_page"))

--- a/app/Services/OnboardingStepRegistrar.php
+++ b/app/Services/OnboardingStepRegistrar.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace App\Services;
 
 use App\Models\AuthObjects\User;
 use App\Settings\SiteSettings;
-use Exception;
 use Filament\Panel;
 use Spatie\Onboard\Facades\Onboard;
 
@@ -25,8 +25,6 @@ class OnboardingStepRegistrar
 
     public function register(?Panel $panel = null, ?User $user = null): void
     {
-        static::$registeredStepKeys = []; // reset per call/request
-
         $panelSlug = $panel?->getId() ?? 'default';
 
         match ($panelSlug) {
@@ -38,11 +36,6 @@ class OnboardingStepRegistrar
 
     protected function registerAdminSteps(?User $user): void
     {
-        if (! $user) {
-            logger()->warning('Admin onboarding skipped: no user.');
-            return;
-        }
-
         $this->addStepOnce('site-settings', function () use ($user) {
             Onboard::addStep('Set your site settings!')
                 ->link('/admin/settings/site-settings')
@@ -58,11 +51,6 @@ class OnboardingStepRegistrar
 
     protected function registerModeratorSteps(?User $user): void
     {
-        if (! $user) {
-            logger()->warning('Moderator onboarding skipped: no user.');
-            return;
-        }
-
         $this->addStepOnce('moderator-reports', function () use ($user) {
             Onboard::addStep('Review flagged comments')
                 ->link('/moderator/reports')
@@ -76,11 +64,6 @@ class OnboardingStepRegistrar
 
     protected function addOptionalIntegrationSteps(?User $user): void
     {
-        if (! $user) {
-            logger()->warning('Optional onboarding skipped: no user.');
-            return;
-        }
-
         foreach (['discord', 'fourthwall', 'twitch'] as $slug) {
             $this->addStepOnce("optional-integration-{$slug}", function () use ($slug, $user) {
                 Onboard::addStep("Visit the {$slug} integration settings")
@@ -92,4 +75,3 @@ class OnboardingStepRegistrar
         }
     }
 }
-

--- a/app/Services/OnboardingStepRegistrar.php
+++ b/app/Services/OnboardingStepRegistrar.php
@@ -1,0 +1,95 @@
+<?php
+namespace App\Services;
+
+use App\Models\AuthObjects\User;
+use App\Settings\SiteSettings;
+use Exception;
+use Filament\Panel;
+use Spatie\Onboard\Facades\Onboard;
+
+class OnboardingStepRegistrar
+{
+    protected static array $registered = [];
+
+    protected static array $registeredStepKeys = [];
+
+    protected function addStepOnce(string $key, callable $callback): void
+    {
+        if (in_array($key, static::$registeredStepKeys, true)) {
+            return;
+        }
+
+        static::$registeredStepKeys[] = $key;
+        $callback();
+    }
+
+    public function register(?Panel $panel = null, ?User $user = null): void
+    {
+        static::$registeredStepKeys = []; // reset per call/request
+
+        $panelSlug = $panel?->getId() ?? 'default';
+
+        match ($panelSlug) {
+            'admin' => $this->registerAdminSteps($user),
+            'moderator' => $this->registerModeratorSteps($user),
+            default => null,
+        };
+    }
+
+    protected function registerAdminSteps(?User $user): void
+    {
+        if (! $user) {
+            logger()->warning('Admin onboarding skipped: no user.');
+            return;
+        }
+
+        $this->addStepOnce('site-settings', function () use ($user) {
+            Onboard::addStep('Set your site settings!')
+                ->link('/admin/settings/site-settings')
+                ->cta('Configure')
+                ->completeIf(fn (SiteSettings $setting) => $setting->isComplete())
+                ->excludeIf(fn () => ! $user->can('is-super-admin') && ! $user->can('is-admin'));
+        });
+
+        $this->registerModeratorSteps($user);
+
+        $this->addOptionalIntegrationSteps($user);
+    }
+
+    protected function registerModeratorSteps(?User $user): void
+    {
+        if (! $user) {
+            logger()->warning('Moderator onboarding skipped: no user.');
+            return;
+        }
+
+        $this->addStepOnce('moderator-reports', function () use ($user) {
+            Onboard::addStep('Review flagged comments')
+                ->link('/moderator/reports')
+                ->cta('Review')
+                ->completeIf(fn () => $user->hasCompletedOnboardingStep('visited_moderator_reports'))
+                ->excludeIf(fn () => ! $user->can('is-super-admin') && ! $user->can('is-admin') && ! $user->can('is-moderator'));
+        });
+
+        $this->addOptionalIntegrationSteps($user);
+    }
+
+    protected function addOptionalIntegrationSteps(?User $user): void
+    {
+        if (! $user) {
+            logger()->warning('Optional onboarding skipped: no user.');
+            return;
+        }
+
+        foreach (['discord', 'fourthwall', 'twitch'] as $slug) {
+            $this->addStepOnce("optional-integration-{$slug}", function () use ($slug, $user) {
+                Onboard::addStep("Visit the {$slug} integration settings")
+                    ->link("/admin/integrations/{$slug}-settings")
+                    ->cta('See Optional Features')
+                    ->completeIf(fn () => $user->hasCompletedOnboardingStep("visited_{$slug}_integration_page"))
+                    ->excludeIf(fn () => ! $user->can('is-super-admin') && ! $user->can('is-admin'));
+            });
+        }
+    }
+}
+

--- a/app/Settings/SiteSettings.php
+++ b/app/Settings/SiteSettings.php
@@ -28,4 +28,35 @@ class SiteSettings extends Settings
     {
         return 'site';
     }
+
+    /**
+     * Onboarding Completion Check
+     */
+    public static function isComplete(): bool
+    {
+        $site_name = app(__CLASS__)->site_name ?? null;
+        $is_active = app(__CLASS__)->site_active ?? null;
+        $site_tagline = app(__CLASS__)->site_tagline ?? null;
+        $can_register = app(__CLASS__)->can_register ?? null;
+        $timezone = app(__CLASS__)->site_timezone ?? null;
+        $date_format = app(__CLASS__)->site_date_format ?? null;
+
+        if ($site_name && $site_name !== 'Streamer.live') {
+            if ($is_active & $is_active !== null) {
+                if ($site_tagline && $site_tagline !== 'Host your own community!') {
+                    if ($can_register !== null) {
+                        return $timezone !== null && $date_format !== null;
+                    }
+
+                    return false;
+                }
+
+                return false;
+            }
+
+            return false;
+        }
+
+        return false;
+    }
 }

--- a/app/Settings/SiteSettings.php
+++ b/app/Settings/SiteSettings.php
@@ -4,59 +4,103 @@ namespace App\Settings;
 
 use App\Models\Settings;
 
+/**
+ * Class SiteSettings
+ *
+ * Represents the settings for the site, including general configuration options
+ * such as site name, logo, registration settings, and timezone preferences.
+ */
 class SiteSettings extends Settings
 {
+    /**
+     * @var string The name of the site.
+     */
     public string $site_name;
 
+    /**
+     * @var bool Indicates whether the site is active.
+     */
     public bool $site_active;
 
+    /**
+     * @var string|null The tagline of the site.
+     */
     public ?string $site_tagline;
 
-    public ?string $site_logo; // Store path or media ID
+    /**
+     * @var string|null The path or media ID for the site logo.
+     */
+    public ?string $site_logo;
 
-    public bool $show_site_name = true; // Shows the name next to the logo in select places
+    /**
+     * @var bool Indicates whether the site name should be displayed next to the logo.
+     */
+    public bool $show_site_name = true;
 
-    public ?string $site_favicon; // Store path or media ID
+    /**
+     * @var string|null The path or media ID for the site favicon.
+     */
+    public ?string $site_favicon;
 
+    /**
+     * @var bool Indicates whether user registration is allowed.
+     */
     public bool $can_register;
 
+    /**
+     * @var string|null The timezone of the site.
+     */
     public ?string $site_timezone;
 
+    /**
+     * @var string|null The date format used by the site.
+     */
     public ?string $site_date_format;
 
+    /**
+     * Returns the group name for the settings.
+     *
+     * @return string The group name.
+     */
     public static function group(): string
     {
         return 'site';
     }
 
     /**
-     * Onboarding Completion Check
+     * Checks if the onboarding process is complete based on the site settings.
+     *
+     * @return bool True if onboarding is complete, false otherwise.
      */
     public static function isComplete(): bool
     {
-        $site_name = app(__CLASS__)->site_name ?? null;
-        $is_active = app(__CLASS__)->site_active ?? null;
-        $site_tagline = app(__CLASS__)->site_tagline ?? null;
-        $can_register = app(__CLASS__)->can_register ?? null;
-        $timezone = app(__CLASS__)->site_timezone ?? null;
-        $date_format = app(__CLASS__)->site_date_format ?? null;
+        $settings = self::_getSettings();
 
-        if ($site_name && $site_name !== 'Streamer.live') {
-            if ($is_active & $is_active !== null) {
-                if ($site_tagline && $site_tagline !== 'Host your own community!') {
-                    if ($can_register !== null) {
-                        return $timezone !== null && $date_format !== null;
-                    }
+        // Check if all required conditions are met
+        return isset($settings['site_name'], $settings['site_active'], $settings['site_tagline']) &&
+            $settings['site_name'] !== 'Streamer.live' &&
+            $settings['site_tagline'] !== 'Host your own community!' &&
+            $settings['can_register'] !== null &&
+            $settings['site_timezone'] !== null &&
+            $settings['site_date_format'] !== null;
+    }
 
-                    return false;
-                }
+    /**
+     * Retrieves the settings properties in a reusable way.
+     *
+     * @return array An associative array of settings properties.
+     */
+    private static function _getSettings(): array
+    {
+        $instance = app(__CLASS__);
 
-                return false;
-            }
-
-            return false;
-        }
-
-        return false;
+        return [
+            'site_name' => $instance->site_name ?? null,
+            'site_active' => $instance->site_active ?? null,
+            'site_tagline' => $instance->site_tagline ?? null,
+            'can_register' => $instance->can_register ?? null,
+            'site_timezone' => $instance->site_timezone ?? null,
+            'site_date_format' => $instance->site_date_format ?? null,
+        ];
     }
 }

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -9,10 +9,11 @@ return [
     App\Providers\FortifyServiceProvider::class,
     App\Providers\HorizonServiceProvider::class,
     App\Providers\JetstreamServiceProvider::class,
+    App\Providers\OnboardingServiceProvider::class,
     App\Providers\TelescopeServiceProvider::class,
+    Froiden\LaravelInstaller\Providers\LaravelInstallerServiceProvider::class,
     Spatie\EloquentSortable\EloquentSortableServiceProvider::class,
+    Xetaio\Mentions\Providers\MentionServiceProvider::class,
     nickurt\Akismet\ServiceProvider::class,
     nickurt\StopForumSpam\ServiceProvider::class,
-    Xetaio\Mentions\Providers\MentionServiceProvider::class,
-    Froiden\LaravelInstaller\Providers\LaravelInstallerServiceProvider::class,
 ];

--- a/composer.json
+++ b/composer.json
@@ -110,6 +110,7 @@
         "spatie/laravel-medialibrary": "^11.12",
         "spatie/laravel-navigation": "^1.3",
         "spatie/laravel-newsletter": "^5.3",
+        "spatie/laravel-onboard": "^2.6",
         "spatie/laravel-permission": "^6.15",
         "spatie/laravel-searchable": "^1.13",
         "spatie/laravel-settings": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "998d1d157b8c0fa8bcd66201d7479907",
+    "content-hash": "150a6dfefefb559eaeb34f70aec3d504",
     "packages": [
         {
             "name": "a21ns1g4ts/filament-short-url",
@@ -15032,6 +15032,76 @@
             "time": "2025-03-26T08:06:07+00:00"
         },
         {
+            "name": "spatie/laravel-onboard",
+            "version": "2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-onboard.git",
+                "reference": "3ce6cd9a88068719f823788856ff17155c6c1d54"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-onboard/zipball/3ce6cd9a88068719f823788856ff17155c6c1d54",
+                "reference": "3ce6cd9a88068719f823788856ff17155c6c1d54",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
+                "php": "^8.0",
+                "spatie/laravel-package-tools": "^1.9.2",
+                "spatie/once": "^3.1"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+                "pestphp/pest": "^1.21|^2.0|^3.0",
+                "pestphp/pest-plugin-laravel": "^1.1|^2.0|^3.0",
+                "phpstan/extension-installer": "^1.1|^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "spatie/laravel-ray": "^1.26"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Onboard": "Spatie\\Onboard\\OnboardFacade"
+                    },
+                    "providers": [
+                        "Spatie\\Onboard\\OnboardServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Onboard\\": "src",
+                    "Spatie\\Onboard\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rias Van der Veken",
+                    "email": "rias@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Laravel package to help track user onboarding steps",
+            "homepage": "https://github.com/spatie/laravel-onboard",
+            "keywords": [
+                "laravel",
+                "laravel-onboard",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-onboard/issues",
+                "source": "https://github.com/spatie/laravel-onboard/tree/2.6.2"
+            },
+            "time": "2025-03-21T08:27:17+00:00"
+        },
+        {
             "name": "spatie/laravel-package-tools",
             "version": "1.92.6",
             "source": {
@@ -24580,6 +24650,6 @@
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -3646,16 +3646,16 @@
         },
         {
             "name": "filament/actions",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/actions.git",
-                "reference": "3fee2c23368e5ee8d4613786b1bed8d98a8073fc"
+                "reference": "9eaddc610d9adc00d738b8b116cea1be35a88f85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/actions/zipball/3fee2c23368e5ee8d4613786b1bed8d98a8073fc",
-                "reference": "3fee2c23368e5ee8d4613786b1bed8d98a8073fc",
+                "url": "https://api.github.com/repos/filamentphp/actions/zipball/9eaddc610d9adc00d738b8b116cea1be35a88f85",
+                "reference": "9eaddc610d9adc00d738b8b116cea1be35a88f85",
                 "shasum": ""
             },
             "require": {
@@ -3695,20 +3695,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-07-08T20:42:21+00:00"
+            "time": "2025-07-16T08:51:11+00:00"
         },
         {
             "name": "filament/filament",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/panels.git",
-                "reference": "b432b938c35467b9626978fb8b72578ec4d162ae"
+                "reference": "af470f710de176796a50b17433e1ef3a70676c88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/panels/zipball/b432b938c35467b9626978fb8b72578ec4d162ae",
-                "reference": "b432b938c35467b9626978fb8b72578ec4d162ae",
+                "url": "https://api.github.com/repos/filamentphp/panels/zipball/af470f710de176796a50b17433e1ef3a70676c88",
+                "reference": "af470f710de176796a50b17433e1ef3a70676c88",
                 "shasum": ""
             },
             "require": {
@@ -3760,20 +3760,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-07-01T09:34:40+00:00"
+            "time": "2025-07-16T08:51:29+00:00"
         },
         {
             "name": "filament/forms",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/forms.git",
-                "reference": "e348d8a92c96fc87b002830848e48559eb0ef715"
+                "reference": "65f81769261ba56a9eafa563ecb25fdfdedb742c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/forms/zipball/e348d8a92c96fc87b002830848e48559eb0ef715",
-                "reference": "e348d8a92c96fc87b002830848e48559eb0ef715",
+                "url": "https://api.github.com/repos/filamentphp/forms/zipball/65f81769261ba56a9eafa563ecb25fdfdedb742c",
+                "reference": "65f81769261ba56a9eafa563ecb25fdfdedb742c",
                 "shasum": ""
             },
             "require": {
@@ -3816,11 +3816,11 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-07-08T20:42:22+00:00"
+            "time": "2025-07-16T08:51:37+00:00"
         },
         {
             "name": "filament/infolists",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/infolists.git",
@@ -3871,7 +3871,7 @@
         },
         {
             "name": "filament/notifications",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/notifications.git",
@@ -3923,7 +3923,7 @@
         },
         {
             "name": "filament/spatie-laravel-media-library-plugin",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-media-library-plugin.git",
@@ -3961,7 +3961,7 @@
         },
         {
             "name": "filament/spatie-laravel-settings-plugin",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-settings-plugin.git",
@@ -4008,7 +4008,7 @@
         },
         {
             "name": "filament/spatie-laravel-tags-plugin",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-tags-plugin.git",
@@ -4046,7 +4046,7 @@
         },
         {
             "name": "filament/spatie-laravel-translatable-plugin",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-translatable-plugin.git",
@@ -4091,16 +4091,16 @@
         },
         {
             "name": "filament/support",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/support.git",
-                "reference": "ec8c7e9e6b49d4f1150a19bfd6fc585c717a857d"
+                "reference": "0bf4856840e160624ba79f43aaaa3ec396140f1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/support/zipball/ec8c7e9e6b49d4f1150a19bfd6fc585c717a857d",
-                "reference": "ec8c7e9e6b49d4f1150a19bfd6fc585c717a857d",
+                "url": "https://api.github.com/repos/filamentphp/support/zipball/0bf4856840e160624ba79f43aaaa3ec396140f1d",
+                "reference": "0bf4856840e160624ba79f43aaaa3ec396140f1d",
                 "shasum": ""
             },
             "require": {
@@ -4146,11 +4146,11 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-07-08T20:42:46+00:00"
+            "time": "2025-07-16T08:51:22+00:00"
         },
         {
             "name": "filament/tables",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/tables.git",
@@ -4202,7 +4202,7 @@
         },
         {
             "name": "filament/widgets",
-            "version": "v3.3.31",
+            "version": "v3.3.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/widgets.git",
@@ -19025,16 +19025,16 @@
         },
         {
             "name": "team-reflex/discord-php",
-            "version": "v10.18.8",
+            "version": "v10.18.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/discord-php/DiscordPHP",
-                "reference": "af99810399a4eb27653d91fb0f720e7822237ad0"
+                "reference": "0578dceb9e7189a7d69b418fe8fe4a44caa7b2fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/discord-php/DiscordPHP/zipball/af99810399a4eb27653d91fb0f720e7822237ad0",
-                "reference": "af99810399a4eb27653d91fb0f720e7822237ad0",
+                "url": "https://api.github.com/repos/discord-php/DiscordPHP/zipball/0578dceb9e7189a7d69b418fe8fe4a44caa7b2fd",
+                "reference": "0578dceb9e7189a7d69b418fe8fe4a44caa7b2fd",
                 "shasum": ""
             },
             "require": {
@@ -19098,7 +19098,7 @@
                 "issues": "https://github.com/discord-php/DiscordPHP/issues",
                 "wiki": "https://github.com/discord-php/DiscordPHP/wiki"
             },
-            "time": "2025-07-15T18:10:25+00:00"
+            "time": "2025-07-16T11:57:14+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -24650,6 +24650,6 @@
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/database/migrations/2025_07_16_154703_create_onboarding_progress_table.php
+++ b/database/migrations/2025_07_16_154703_create_onboarding_progress_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2025_07_16_154703_create_onboarding_progress_table.php
+++ b/database/migrations/2025_07_16_154703_create_onboarding_progress_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration {
+return new class extends Migration
+{
     /**
      * Run the migrations.
      */

--- a/database/migrations/2025_07_16_154703_create_onboarding_progress_table.php
+++ b/database/migrations/2025_07_16_154703_create_onboarding_progress_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('onboarding_progress', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('step_key');
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+            $table->unique(['user_id', 'step_key']); // Prevent duplicates
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('onboarding_progress');
+    }
+};

--- a/database/settings/2025_07_15_123000_add_additional_site_settings_to_site_settings.php
+++ b/database/settings/2025_07_15_123000_add_additional_site_settings_to_site_settings.php
@@ -6,13 +6,21 @@ return new class extends SettingsMigration
 {
     public function up(): void
     {
-        $this->migrator->add('site.site_timezone', 'UTC');
-        $this->migrator->add('site.site_date_format', 'MM-DD-YYYY');
+        if (!$this->migrator->exists('site.site_timezone')) {
+            $this->migrator->add('site.site_timezone', 'UTC');
+        }
+        if (!$this->migrator->exists('site.site_date_format')) {
+            $this->migrator->add('site.site_date_format', 'MM-DD-YYYY');
+        }
     }
 
     public function down(): void
     {
-        $this->migrator->delete('site.site_timezone');
-        $this->migrator->delete('site.site_date_format');
+        if ($this->migrator->exists('site.site_timezone')) {
+            $this->migrator->delete('site.site_timezone');
+        }
+        if ($this->migrator->exists('site.site_date_format')) {
+            $this->migrator->delete('site.site_date_format');
+        }
     }
 };

--- a/database/settings/2025_07_15_123000_add_additional_site_settings_to_site_settings.php
+++ b/database/settings/2025_07_15_123000_add_additional_site_settings_to_site_settings.php
@@ -2,8 +2,7 @@
 
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
-return new class extends SettingsMigration
-{
+return new class () extends SettingsMigration {
     public function up(): void
     {
         if (!$this->migrator->exists('site.site_timezone')) {

--- a/database/settings/2025_07_15_123000_add_additional_site_settings_to_site_settings.php
+++ b/database/settings/2025_07_15_123000_add_additional_site_settings_to_site_settings.php
@@ -1,0 +1,18 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('site.site_timezone', 'UTC');
+        $this->migrator->add('site.site_date_format', 'MM-DD-YYYY');
+    }
+
+    public function down(): void
+    {
+        $this->migrator->delete('site.site_timezone');
+        $this->migrator->delete('site.site_date_format');
+    }
+};

--- a/resources/css/filament/admin/tailwind.config.js
+++ b/resources/css/filament/admin/tailwind.config.js
@@ -1,12 +1,12 @@
-import preset from '../../../../vendor/filament/filament/tailwind.config.preset'
+import preset from "../../../../vendor/filament/filament/tailwind.config.preset";
 
 export default {
-  presets: [preset],
-  content: [
-    './app/Filament/**/*.php',
-    './resources/views/filament/**/*.blade.php',
-    './vendor/filament/**/*.blade.php',
-      './vendor/guava/calendar/resources/**/*.blade.php',
-      './vendor/guava/tutorials/resources/**/*.php',
-  ]
-}
+    presets: [preset],
+    content: [
+        "./app/Filament/**/*.php",
+        "./resources/views/filament/**/*.blade.php",
+        "./vendor/filament/**/*.blade.php",
+        "./vendor/guava/calendar/resources/**/*.blade.php",
+        "./vendor/guava/tutorials/resources/**/*.php",
+    ],
+};

--- a/resources/css/filament/admin/tailwind.config.js
+++ b/resources/css/filament/admin/tailwind.config.js
@@ -7,5 +7,6 @@ export default {
     './resources/views/filament/**/*.blade.php',
     './vendor/filament/**/*.blade.php',
       './vendor/guava/calendar/resources/**/*.blade.php',
+      './vendor/guava/tutorials/resources/**/*.php',
   ]
 }

--- a/resources/css/filament/moderation/tailwind.config.js
+++ b/resources/css/filament/moderation/tailwind.config.js
@@ -1,12 +1,12 @@
-import preset from '../../../../vendor/filament/filament/tailwind.config.preset'
+import preset from "../../../../vendor/filament/filament/tailwind.config.preset";
 
 export default {
-  presets: [preset],
-  content: [
-    './app/Filament/Moderation/**/*.php',
-    './resources/views/filament/moderation/**/*.blade.php',
-      './vendor/filament/**/*.blade.php',
-      './vendor/guava/calendar/resources/**/*.blade.php',
-      './vendor/guava/tutorials/resources/**/*.php',
-  ]
-}
+    presets: [preset],
+    content: [
+        "./app/Filament/Moderation/**/*.php",
+        "./resources/views/filament/moderation/**/*.blade.php",
+        "./vendor/filament/**/*.blade.php",
+        "./vendor/guava/calendar/resources/**/*.blade.php",
+        "./vendor/guava/tutorials/resources/**/*.php",
+    ],
+};

--- a/resources/css/filament/moderation/tailwind.config.js
+++ b/resources/css/filament/moderation/tailwind.config.js
@@ -5,6 +5,8 @@ export default {
   content: [
     './app/Filament/Moderation/**/*.php',
     './resources/views/filament/moderation/**/*.blade.php',
-    './vendor/filament/**/*.blade.php'
+      './vendor/filament/**/*.blade.php',
+      './vendor/guava/calendar/resources/**/*.blade.php',
+      './vendor/guava/tutorials/resources/**/*.php',
   ]
 }

--- a/resources/views/filament/widgets/account-widget.blade.php
+++ b/resources/views/filament/widgets/account-widget.blade.php
@@ -4,7 +4,7 @@
     $steps = $onboarding->steps;
     $totalSteps = count($steps);
     $completedSteps = collect($steps)->filter(fn ($step) => $step->complete())->count();
-    $progress = $totalSteps > 0 ? intval(($completedSteps / $totalSteps) * 100) : 0;
+    $progress = $totalSteps > 0 ? (int) (($completedSteps / $totalSteps) * 100) : 0;
     $dismissed = session('onboarding_dismissed', false);
 @endphp
 
@@ -12,7 +12,7 @@
     <x-filament::section>
         {{-- Top User Info --}}
         <div class="flex items-center gap-x-3">
-            <x-filament-panels::avatar.user size="lg" :user="$user" />
+            <x-filament-panels::avatar.user size="lg" :user="$user"/>
 
             <div class="flex-1">
                 <h2 class="text-base font-semibold leading-6 text-gray-950 dark:text-white">
@@ -43,28 +43,9 @@
                 </x-filament::button>
             </form>
         </div>
-
         {{-- Onboarding Section --}}
-        @if (empty($steps))
-            <p class="text-red-500">No onboarding steps found.</p>
-        @endif
-        @if (! $onboarding->inProgress())
-            <p class="text-red-500">Onboarding is not in progress.</p>
-        @endif
-        @if ($dismissed)
-            <p class="text-yellow-500">Onboarding is dismissed in session.</p>
-        @endif
-    @if ($onboarding->inProgress() && !$dismissed)
+        @if ($onboarding->inProgress() && !$dismissed)
             <x-filament::card class="mt-4 bg-gray-50 dark:bg-gray-800 relative">
-                {{-- Dismiss button --}}
-                <form method="post" action="#" class="absolute top-2 right-2">
-                    @csrf
-                    <button type="submit" class="text-sm text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
-                        <x-fas-xmark class="w-4 h-4" />
-                        <span class="sr-only">Dismiss</span>
-                    </button>
-                </form>
-
                 {{-- Progress Header --}}
                 <div class="mb-2">
                     <h3 class="text-sm font-medium text-gray-800 dark:text-gray-200">
@@ -80,18 +61,18 @@
                         {{ $completedSteps }} of {{ $totalSteps }} steps completed
                     </p>
                 </div>
-
+                <br/>
                 {{-- Steps --}}
                 <ul class="space-y-3 mt-3">
                     @foreach ($steps as $step)
                         <li class="flex items-start gap-2">
                             @if ($step->complete())
-                                <x-far-square-check class="text-success mt-1" height="1.5rem" />
+                                <x-far-square-check class="text-success mt-1" height="1.5rem"/>
                                 <div class="flex-1 text-sm text-gray-500 line-through">
                                     <span class="font-semibold">{{ $loop->iteration }}. {{ $step->title }}</span>
                                 </div>
                             @else
-                                <x-far-square class="text-gray-400 mt-1" height="1.5rem" />
+                                <x-far-square class="text-gray-400 mt-1" height="1.5rem"/>
                                 <div class="flex-1 text-sm text-gray-800 dark:text-gray-200">
                                     <div class="font-semibold">{{ $loop->iteration }}. {{ $step->title }}</div>
                                     @if ($step->cta)
@@ -107,6 +88,14 @@
                         </li>
                     @endforeach
                 </ul>
+                <br/>
+                {{-- Dismiss button --}}
+                <form method="post" action="#" class="relative bottom-2 left-10">
+                    @csrf
+                    <button type="submit" class="text-sm text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
+                        <span><x-fas-xmark class="w-4 h-4"/> Dismiss</span>
+                    </button>
+                </form>
             </x-filament::card>
         @endif
     </x-filament::section>

--- a/resources/views/filament/widgets/account-widget.blade.php
+++ b/resources/views/filament/widgets/account-widget.blade.php
@@ -5,7 +5,7 @@
     $totalSteps = count($steps);
     $completedSteps = collect($steps)->filter(fn ($step) => $step->complete())->count();
     $progress = $totalSteps > 0 ? (int) (($completedSteps / $totalSteps) * 100) : 0;
-    $dismissed = session('onboarding_dismissed', false);
+    $dismissed = $user->hasDismissedOnboarding();
 @endphp
 
 <x-filament-widgets::widget class="fi-account-widget">
@@ -44,7 +44,7 @@
             </form>
         </div>
         {{-- Onboarding Section --}}
-        @if ($onboarding->inProgress() && !$dismissed)
+        @if (!$dismissed && $onboarding->inProgress())
             <x-filament::card class="mt-4 bg-gray-50 dark:bg-gray-800 relative">
                 {{-- Progress Header --}}
                 <div class="mb-2">
@@ -90,7 +90,9 @@
                 </ul>
                 <br/>
                 {{-- Dismiss button --}}
-                <form method="post" action="#" class="relative bottom-2 left-10">
+                <form method="post"
+                      action="{{ route('onboarding.dismiss', ['panel' => filament()->getCurrentPanel()?->getId() ?? 'admin']) }}"
+                      class="relative bottom-2 left-10">
                     @csrf
                     <button type="submit" class="text-sm text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
                         <span><x-fas-xmark class="w-4 h-4"/> Dismiss</span>

--- a/resources/views/filament/widgets/account-widget.blade.php
+++ b/resources/views/filament/widgets/account-widget.blade.php
@@ -1,0 +1,76 @@
+@php
+    $user = filament()->auth()->user();
+@endphp
+
+<x-filament-widgets::widget class="fi-account-widget">
+    <x-filament::section>
+        <div class="flex items-center gap-x-3">
+            <x-filament-panels::avatar.user size="lg" :user="$user"/>
+
+            <div class="flex-1">
+                <h2 class="text-base font-semibold leading-6 text-gray-950 dark:text-white">
+                    {{ __('filament-panels::widgets/account-widget.welcome', ['app' => config('app.name')]) }}
+                </h2>
+
+                <p class="text-sm text-gray-500 dark:text-gray-400">
+                    {{ filament()->getUserName($user) }}
+                </p>
+            </div>
+
+            <form
+                action="{{ filament()->getLogoutUrl() }}"
+                method="post"
+                class="my-auto"
+            >
+                @csrf
+
+                <x-filament::button
+                    color="gray"
+                    icon="fas-right-from-bracket"
+                    icon-alias="panels::widgets.account.logout-button"
+                    labeled-from="sm"
+                    tag="button"
+                    type="submit"
+                >
+                    {{ __('filament-panels::widgets/account-widget.actions.logout.label') }}
+                </x-filament::button>
+            </form>
+        </div>
+
+        @if ($user->onboarding()->inProgress())
+            <x-filament::card class="mt-4 bg-gray-50 dark:bg-gray-800">
+                <h3 class="text-sm font-medium text-gray-800 dark:text-gray-200 mb-2">
+                    👋 Let's get you started
+                </h3>
+
+                <ul class="space-y-2">
+                    @foreach ($user->onboarding()->steps as $step)
+                        <li class="flex items-start gap-2">
+                            @if ($step->complete())
+                                <x-far-square-check class="text-success mt-1" height="2rem"/>
+                                <div class="flex-1 text-sm text-gray-500 line-through">
+                                    <span class="font-semibold">{{ $loop->iteration }}. {{ $step->title }}</span>
+                                </div>
+                            @else
+                                <x-far-square class="text-gray-400 mt-1" height="2rem"/>
+                                <div class="flex-1 text-sm text-gray-800 dark:text-gray-200">
+                                    <span>
+                                        <div class="font-semibold">{{ $loop->iteration }}. {{ $step->title }}</div>
+                                    @if ($step->cta)
+                                            <a
+                                                href="{{ $step->link }}"
+                                                class="text-primary-600 hover:underline text-sm"
+                                            >
+                                            {{ $step->cta }}
+                                        </a>
+                                        @endif
+                                    </span>
+                                </div>
+                            @endif
+                        </li>
+                    @endforeach
+                </ul>
+            </x-filament::card>
+        @endif
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/resources/views/livewire/onboarding-widget.blade.php
+++ b/resources/views/livewire/onboarding-widget.blade.php
@@ -1,0 +1,23 @@
+<x-filament-widgets::widget>
+    <x-filament::section>
+        @if (auth()->user()->onboarding()->inProgress())
+            <div>
+                @foreach (auth()->user()->onboarding()->steps as $step)
+                    <span>
+                @if($step->complete())
+                            <x-far-square-check height="1rem"/>
+                            <s>{{ $loop->iteration }}. {{ $step->title }}</s>
+                        @else
+                            <x-far-square height="1rem"/>
+                            {{ $loop->iteration }}. {{ $step->title }}
+                        @endif
+            </span>
+
+                    <a href="{{ $step->link }}" {{ $step->complete() ? 'disabled' : '' }}>
+                        {{ $step->cta }}
+                    </a>
+                @endforeach
+            </div>
+        @endif
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,7 +37,7 @@ use Shieldon\Firewall\Panel;
 
 Route::any('/firewall/panel/{path?}', function () {
 
-    $panel = new Panel;
+    $panel = new Panel();
     $panel->csrf(['_token' => csrf_token()]);
     $panel->entry();
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\EventController;
 use App\Http\Controllers\FabricatorPageController;
 use App\Http\Controllers\IconController;
 use App\Http\Controllers\NewsletterController;
+use App\Http\Controllers\OnboardingController;
 use App\Http\Controllers\OrderController;
 use App\Http\Controllers\ProductReviewController;
 use App\Http\Controllers\ReactionController;
@@ -36,7 +37,7 @@ use Shieldon\Firewall\Panel;
 
 Route::any('/firewall/panel/{path?}', function () {
 
-    $panel = new Panel();
+    $panel = new Panel;
     $panel->csrf(['_token' => csrf_token()]);
     $panel->entry();
 
@@ -69,7 +70,7 @@ Route::middleware([PreventRequestsDuringMaintenance::class])->group(function () 
         'firewall',
         'auth.banned',
         'ip.banned',
-        'logout.banned'
+        'logout.banned',
     ])->group(function () {
         Route::get('/dashboard', function () {
             return view('dashboard');
@@ -131,7 +132,7 @@ Route::middleware([PreventRequestsDuringMaintenance::class])->group(function () 
         'signed',
         'auth.banned',
         'ip.banned',
-        'logout.banned'
+        'logout.banned',
     ])->name('verification.verify');
 
     /**
@@ -148,7 +149,7 @@ Route::middleware([PreventRequestsDuringMaintenance::class])->group(function () 
         config('jetstream.auth_session'),
         'auth.banned',
         'ip.banned',
-        'logout.banned'
+        'logout.banned',
     ])->name('verification.notice');
 
     /**
@@ -166,7 +167,7 @@ Route::middleware([PreventRequestsDuringMaintenance::class])->group(function () 
         'auth.banned',
         'ip.banned',
         'logout.banned',
-        'throttle:6,1'
+        'throttle:6,1',
     ])->name('verification.send');
 
     /**
@@ -183,7 +184,7 @@ Route::middleware([PreventRequestsDuringMaintenance::class])->group(function () 
         config('jetstream.auth_session'),
         'auth.banned',
         'ip.banned',
-        'logout.banned'
+        'logout.banned',
     ])->name('verification.complete');
 
     Route::get('/team-invitations/{invitation}', [TeamInvitationController::class, 'accept'])
@@ -200,7 +201,7 @@ Route::middleware([PreventRequestsDuringMaintenance::class])->group(function () 
                 'auth',
                 'auth.banned',
                 'ip.banned',
-                'logout.banned'
+                'logout.banned',
             ])
             ->name('comment.submit');
         // Post reactions
@@ -211,7 +212,7 @@ Route::middleware([PreventRequestsDuringMaintenance::class])->group(function () 
                     'auth',
                     'auth.banned',
                     'ip.banned',
-                    'logout.banned'
+                    'logout.banned',
                 ]
             );
 
@@ -222,7 +223,7 @@ Route::middleware([PreventRequestsDuringMaintenance::class])->group(function () 
                 'auth',
                 'auth.banned',
                 'ip.banned',
-                'logout.banned'
+                'logout.banned',
             ]);
     });
 
@@ -268,7 +269,7 @@ Route::middleware([PreventRequestsDuringMaintenance::class])->group(function () 
                     'auth',
                     'auth.banned',
                     'ip.banned',
-                    'logout.banned'
+                    'logout.banned',
                 ])
                 ->name('product.review.submit');
         });
@@ -279,7 +280,7 @@ Route::middleware([PreventRequestsDuringMaintenance::class])->group(function () 
 
         foreach ($fonts as $font) {
             $url = $font->is_builtin
-                ? asset("{$font->file_path}")
+                ? asset((string) ($font->file_path))
                 : $font->getFirstMediaUrl('fonts');
             $wMin = $font->weight_min ?? 100;
             $wMax = $font->weight_max ?? 900;
@@ -305,6 +306,8 @@ CSS;
         ->where('slug', '^(?!api\/|public\/|storage\/|auth\/|build\/).*$')
         ->name('fabricator.page.global.fallback');
 });
+
+Route::middleware(['web', 'auth'])->post('/{panel}/onboarding/dismiss', [OnboardingController::class, 'dismiss'])->name('onboarding.dismiss');
 
 // Kick off the OAuth flow, saving your “context” in session
 Route::get('auth/twitch/redirect', function (Request $request) {


### PR DESCRIPTION
This sets up the system for onboarding, and some starter steps, but will need more later for full release.
Addresses #340

## Summary by Sourcery

Set up a step-by-step onboarding framework for site administrators and moderators within Filament by integrating spatie/laravel-onboard and tracking progress through a new OnboardingProgress model and user API.

New Features:
- Add onboarding progress tracking model and migration, user methods, and Onboardable traits for users and settings.
- Introduce OnboardingStepRegistrar to define and register tutorial steps based on panel context and user roles.

Enhancements:
- Display onboarding steps and progress in a custom Filament AccountWidget and Livewire widget.
- Hook into integration pages (Discord, Fourthwall, Twitch) and site settings completion logic to automatically mark steps as done and add timezone/date format settings.

Build:
- Add spatie/laravel-onboard dependency and register OnboardingServiceProvider and related providers.