### PR TITLE
Improve IP filtering with caching and auto-blacklisting.

### DIFF
--- a/app/Http/Middleware/CheckIPFilter.php
+++ b/app/Http/Middleware/CheckIPFilter.php
@@ -3,10 +3,13 @@
 namespace App\Http\Middleware;
 
 use App\Models\SecurityObjects\GeoFilter;
+use App\Models\SecurityObjects\IPFilter;
 use App\Services\GeoLocationService;
 use Closure;
-use App\Models\SecurityObjects\IPFilter;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Component\HttpFoundation\Response;
 
 class CheckIPFilter
@@ -14,22 +17,39 @@ class CheckIPFilter
     /**
      * Handle an incoming request.
      *
-     * @param Closure(Request): (Response) $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {
         $ip = $request->ip();
 
         // IP blacklist
-        if (IPFilter::where('type', 'blacklist')->where('ip_address', $ip)->exists()) {
+        $blacklist = Cache::remember(
+            'ip_filter:blacklist',
+            config('ip-filter.cache_ttl'),
+            fn () => IPFilter::where('type', 'blacklist')
+                ->pluck('ip_address')
+                ->toArray()
+        );
+
+        // IP blacklist
+        if (in_array($ip, $blacklist, true)) {
             abort(403, 'Access denied: Your IP is blacklisted.');
         }
 
         // IP whitelist (if enabled)
-        if (config('ip-filter.whitelist_enabled')
-            && ! IPFilter::where('type', 'whitelist')->where('ip_address', $ip)->exists()
-        ) {
-            abort(403, 'Access denied: Your IP isn’t whitelisted.');
+        if (config('ip-filter.whitelist_enabled')) {
+            $whitelist = Cache::remember(
+                'ip_filter:whitelist',
+                config('ip-filter.cache_ttl'),
+                fn () => IPFilter::where('type', 'whitelist')
+                    ->pluck('ip_address')
+                    ->toArray()
+            );
+
+            if (! in_array($ip, $whitelist, true)) {
+                abort(403, 'Access denied: Your IP isn’t whitelisted.');
+            }
         }
 
         // Geo-lookup
@@ -47,11 +67,51 @@ class CheckIPFilter
                 if (config('ip-filter.country_whitelist_enabled')
                     && ! GeoFilter::where('type', 'whitelist')->where('country_code', $cc)->exists()
                 ) {
-                    abort(403, "Access denied: Only selected countries are allowed.");
+                    abort(403, 'Access denied: Only selected countries are allowed.');
                 }
             }
         }
 
-        return $next($request);
+        $response = $next($request);
+
+        // **only in production** do we count 404s
+        if ($response->getStatusCode() === 404 && app()->environment('production')) {
+            // skip excluded IPs (single or CIDR)…
+            foreach (config('ip-filter.exclude_ips', []) as $cidr) {
+                if (IpUtils::checkIp($ip, [$cidr])) {
+                    return $response;
+                }
+            }
+
+            $path = '/'.$request->path();
+            foreach (config('ip-filter.suspicious_patterns', []) as $pattern) {
+                if (preg_match($pattern, $path)) {
+                    $cacheKey = "ip_filter:{$ip}:bad404s";
+                    // initialize with TTL if not present
+                    if (! Cache::has($cacheKey)) {
+                        Cache::put($cacheKey, 0, config('ip-filter.suspicious_ttl'));
+                    }
+                    $count = Cache::increment($cacheKey);
+
+                    // auto‐blacklist?
+                    if ($count >= config('ip-filter.404_threshold')) {
+                        Log::warning("Auto-blacklisting {$ip}: exceeded 404 threshold ({$count})", [
+                            'threshold' => config('ip-filter.404_threshold'),
+                            'path' => $path,
+                        ]);
+                        IPFilter::firstOrCreate(
+                            ['ip_address' => $ip, 'type' => 'blacklist'],
+                            [
+                                'reason' => "Auto‐blacklisted after {$count} 404s to suspicious paths",
+                                'source' => 'auto',
+                            ]
+                        );
+                    }
+                    break;
+                }
+            }
+        }
+
+        return $response;
     }
 }

--- a/app/Http/Middleware/CheckIPFilter.php
+++ b/app/Http/Middleware/CheckIPFilter.php
@@ -14,104 +14,119 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CheckIPFilter
 {
-    /**
-     * Handle an incoming request.
-     *
-     * @param  Closure(Request): (Response)  $next
-     */
     public function handle(Request $request, Closure $next): Response
     {
         $ip = $request->ip();
 
-        // IP blacklist
-        $blacklist = Cache::remember(
-            'ip_filter:blacklist',
-            config('ip-filter.cache_ttl'),
-            fn () => IPFilter::where('type', 'blacklist')
-                ->pluck('ip_address')
-                ->toArray()
-        );
-
-        // IP blacklist
-        if (in_array($ip, $blacklist, true)) {
-            abort(403, 'Access denied: Your IP is blacklisted.');
-        }
-
-        // IP whitelist (if enabled)
-        if (config('ip-filter.whitelist_enabled')) {
-            $whitelist = Cache::remember(
-                'ip_filter:whitelist',
-                config('ip-filter.cache_ttl'),
-                fn () => IPFilter::where('type', 'whitelist')
-                    ->pluck('ip_address')
-                    ->toArray()
-            );
-
-            if (! in_array($ip, $whitelist, true)) {
-                abort(403, 'Access denied: Your IP isn’t whitelisted.');
-            }
-        }
-
-        // Geo-lookup
-        if (config('ip-filter.geo_enabled')) {
-            $geo = app(GeoLocationService::class)->getGeoData($request->ip());
-            if ($geo) {
-                $cc = $geo['country']; // e.g. "US"
-
-                // country blacklist
-                if (GeoFilter::where('type', 'blacklist')->where('country_code', $cc)->exists()) {
-                    abort(403, "Access denied: Connections from {$geo['country_name']} are blocked.");
-                }
-
-                // country whitelist (only allow these when enabled)
-                if (config('ip-filter.country_whitelist_enabled')
-                    && ! GeoFilter::where('type', 'whitelist')->where('country_code', $cc)->exists()
-                ) {
-                    abort(403, 'Access denied: Only selected countries are allowed.');
-                }
-            }
-        }
+        $this->enforceBlacklist($ip);
+        $this->enforceWhitelist($ip);
+        $this->enforceGeoRestrictions($ip);
 
         $response = $next($request);
 
-        // **only in production** do we count 404s
-        if ($response->getStatusCode() === 404 && app()->environment('production')) {
-            // skip excluded IPs (single or CIDR)…
-            foreach (config('ip-filter.exclude_ips', []) as $cidr) {
-                if (IpUtils::checkIp($ip, [$cidr])) {
-                    return $response;
-                }
-            }
+        $this->trackSuspicious404s($request, $response, $ip);
 
-            $path = '/'.$request->path();
-            foreach (config('ip-filter.suspicious_patterns', []) as $pattern) {
-                if (preg_match($pattern, $path)) {
-                    $cacheKey = "ip_filter:{$ip}:bad404s";
-                    // initialize with TTL if not present
-                    if (! Cache::has($cacheKey)) {
-                        Cache::put($cacheKey, 0, config('ip-filter.suspicious_ttl'));
-                    }
-                    $count = Cache::increment($cacheKey);
+        return $response;
+    }
 
-                    // auto‐blacklist?
-                    if ($count >= config('ip-filter.404_threshold')) {
-                        Log::warning("Auto-blacklisting {$ip}: exceeded 404 threshold ({$count})", [
-                            'threshold' => config('ip-filter.404_threshold'),
-                            'path' => $path,
-                        ]);
-                        IPFilter::firstOrCreate(
-                            ['ip_address' => $ip, 'type' => 'blacklist'],
-                            [
-                                'reason' => "Auto‐blacklisted after {$count} 404s to suspicious paths",
-                                'source' => 'auto',
-                            ]
-                        );
-                    }
-                    break;
-                }
+    protected function enforceBlacklist(string $ip): void
+    {
+        if (in_array($ip, $this->getIpList('blacklist'), true)) {
+            abort(403, 'Access denied: Your IP is blacklisted.');
+        }
+    }
+
+    protected function enforceWhitelist(string $ip): void
+    {
+        if (! config('ip-filter.whitelist_enabled')) {
+            return;
+        }
+
+        if (! in_array($ip, $this->getIpList('whitelist'), true)) {
+            abort(403, 'Access denied: Your IP isn’t whitelisted.');
+        }
+    }
+
+    protected function enforceGeoRestrictions(string $ip): void
+    {
+        if (! config('ip-filter.geo_enabled')) {
+            return;
+        }
+
+        $geo = app(GeoLocationService::class)->getGeoData($ip);
+        if (empty($geo)) {
+            return;
+        }
+
+        $country = $geo['country'];
+        $name = $geo['country_name'];
+
+        if (GeoFilter::where('type', 'blacklist')
+            ->where('country_code', $country)
+            ->exists()
+        ) {
+            abort(403, "Access denied: Connections from {$name} are blocked.");
+        }
+
+        if (config('ip-filter.country_whitelist_enabled')
+            && ! GeoFilter::where('type', 'whitelist')
+                ->where('country_code', $country)
+                ->exists()
+        ) {
+            abort(403, 'Access denied: Only selected countries are allowed.');
+        }
+    }
+
+    protected function trackSuspicious404s(Request $request, Response $response, string $ip): void
+    {
+        if ($response->getStatusCode() !== 404 || ! app()->environment('production')) {
+            return;
+        }
+
+        // exempt local/CIDR IPs
+        foreach (config('ip-filter.exclude_ips', []) as $cidr) {
+            if (IpUtils::checkIp($ip, [$cidr])) {
+                return;
             }
         }
 
-        return $response;
+        $path = '/'.$request->path();
+        foreach (config('ip-filter.suspicious_patterns', []) as $pattern) {
+            if (! preg_match($pattern, $path)) {
+                continue;
+            }
+
+            $cacheKey = "ip_filter:{$ip}:bad404s";
+
+            // ensure the key exists with TTL
+            Cache::remember($cacheKey, config('ip-filter.suspicious_ttl'), fn () => 0);
+            $count = Cache::increment($cacheKey);
+
+            if ($count >= config('ip-filter.404_threshold')) {
+                Log::warning("Auto-blacklisting {$ip}: {$count} 404s to {$path}");
+                IPFilter::firstOrCreate(
+                    ['ip_address' => $ip, 'type' => 'blacklist'],
+                    [
+                        'reason' => "Auto-blacklisted after {$count} 404s to suspicious paths",
+                        'source' => 'auto',
+                    ]
+                );
+            }
+
+            break;
+        }
+    }
+
+    protected function getIpList(string $type): array
+    {
+        $cacheKey = "ip_filter:{$type}";
+
+        return Cache::remember(
+            $cacheKey,
+            config('ip-filter.cache_ttl'),
+            fn () => IPFilter::where('type', $type)
+                ->pluck('ip_address')
+                ->toArray()
+        );
     }
 }

--- a/app/Models/SecurityObjects/IPFilter.php
+++ b/app/Models/SecurityObjects/IPFilter.php
@@ -3,12 +3,25 @@
 namespace App\Models\SecurityObjects;
 
 use App\Models\BaseModel;
+use Illuminate\Support\Facades\Cache;
 
 class IPFilter extends BaseModel
 {
     protected $fillable = ['ip_address', 'type', 'reason', 'source'];
 
     protected $table = 'ip_filters';
+
+    protected static function booted()
+    {
+        static::saved(function () {
+            Cache::forget('ip_filter:blacklist');
+            Cache::forget('ip_filter:whitelist');
+        });
+        static::deleted(function () {
+            Cache::forget('ip_filter:blacklist');
+            Cache::forget('ip_filter:whitelist');
+        });
+    }
 
     public static function rules(): array
     {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -78,7 +78,7 @@ class AppServiceProvider extends ServiceProvider
             );
         });
 
-        $this->app->singleton('secure-guest-mode', fn ($app) => new SecureGuestModeService());
+        $this->app->singleton('secure-guest-mode', fn ($app) => new SecureGuestModeService);
 
         $this->app->tag(
             [
@@ -110,6 +110,12 @@ class AppServiceProvider extends ServiceProvider
 
         Cache::remember('ip_filter:blacklist', 3600, function () {
             return IPFilter::where('type', 'blacklist')
+                ->pluck('ip_address')
+                ->all();
+        });
+
+        Cache::remember('ip_filter:whitelist', 3600, function () {
+            return IPFilter::where('type', 'whitelist')
                 ->pluck('ip_address')
                 ->all();
         });

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -78,7 +78,7 @@ class AppServiceProvider extends ServiceProvider
             );
         });
 
-        $this->app->singleton('secure-guest-mode', fn ($app) => new SecureGuestModeService);
+        $this->app->singleton('secure-guest-mode', fn ($app) => new SecureGuestModeService());
 
         $this->app->tag(
             [

--- a/config/ip-filter.php
+++ b/config/ip-filter.php
@@ -4,4 +4,29 @@ return [
     'whitelist_enabled' => false,
     'country_whitelist_enabled' => false,
     'geo_enabled' => env('IP_FILTER_GEO_ENABLED', false),
+    // how long to cache allow/deny lists (seconds)
+    'cache_ttl' => env('IP_FILTER_CACHE_TTL', 3600),
+    // How many 404s on “suspicious” paths before auto‐blacklisting
+    '404_threshold' => 10,
+
+    // Time window (seconds) to reset the 404 counter
+    'suspicious_ttl' => 3600, // 1 hour
+
+    // Regexes for paths to consider “probing” attacks
+    'suspicious_patterns' => [
+        '/(?:^|\/)\.env$/i',
+        '/wp-login\.php$/i',
+        '/wp-admin/i',
+        '/xmlrpc\.php$/i',
+        '/(?:^|\/)(?:config|\.git)\/?/i',
+        '/administrator/i',
+        '/admin/i',
+    ],
+
+    'exclude_ips' => [
+        '127.0.0.1',
+        '::1',
+        '192.168.0.0/16',
+        // etc.
+    ],
 ];

--- a/database/migrations/2025_07_22_174406_add_indexing_to_ip_filters_table.php
+++ b/database/migrations/2025_07_22_174406_add_indexing_to_ip_filters_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2025_07_22_174406_add_indexing_to_ip_filters_table.php
+++ b/database/migrations/2025_07_22_174406_add_indexing_to_ip_filters_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ip_filters', function (Blueprint $table) {
+            $table->index(['type', 'ip_address'], 'ip_filters_type_address_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ip_filters', function (Blueprint $table) {
+            $table->dropIndex(['type', 'ip_address']);
+        });
+    }
+};

--- a/database/migrations/2025_07_22_174406_add_indexing_to_ip_filters_table.php
+++ b/database/migrations/2025_07_22_174406_add_indexing_to_ip_filters_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration {
+return new class extends Migration
+{
     /**
      * Run the migrations.
      */
@@ -21,7 +22,7 @@ return new class () extends Migration {
     public function down(): void
     {
         Schema::table('ip_filters', function (Blueprint $table) {
-            $table->dropIndex(['type', 'ip_address']);
+            $table->dropIndex('ip_filters_type_address_index');
         });
     }
 };


### PR DESCRIPTION
Implemented caching for IP blacklists and whitelists to enhance performance. Added configuration for 404 counting and suspicious patterns to enable automatic blacklisting of malicious IPs. Included migration for better indexing of the `ip_filters` table to optimize database queries.

## Summary by Sourcery

Implement caching for IP filtering with automatic blacklist invalidation, refactor middleware enforcement, add auto-blacklisting based on configurable 404 patterns, and optimize the ip_filters table with an index

New Features:
- Automatically blacklist IPs that exceed a configurable number of 404 hits on suspicious endpoints
- Cache IP blacklist and whitelist entries to reduce database queries
- Support configurable regex patterns, thresholds, and exclusion IPs for suspicious path detection

Enhancements:
- Refactor CheckIPFilter middleware into separate methods for blacklist, whitelist, and geo restrictions
- Preload and invalidate IP filter caches in the model boot and app service provider
- Add a database index on ip_filters (type, ip_address) to optimize lookup performance